### PR TITLE
Add add-on store endpoint examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,31 @@ Notes:
 - The file will include translations (if available) for the displayable metadata.
 
 This simplifies the processing on the hosting (E.G NV Access) server.
-To fetch the latest add-ons for `<NVDA API Version X>`, the server can concatenate the appropriate JSON files that match a glob: `/<NVDA API Version X>/*/stable.json`.
-Similarly, to fetch the latest version of an add-on with `<Addon-ID>` for `<NVDA API Version X>`. The server can return the data at `/<NVDA API Version X>/<addon-ID>/stable.json`.
-Using the NV Access server as the endpoint for this is important in case the implementation has to change or be migrated
-away from GitHub for some reason.
+
+## NV Access Add-on Store endpoints
+
+Using the NV Access server as the endpoint for this is important in case the implementation has to change or be migrated away from GitHub for some reason.
+
+### `GET` All
+Get a complete list of the latest add-on releases.
+Includes both stable and beta versions
+
+- Format: `https://www.nvaccess.org/addonStore/<language>/all/<NVDA API Version>.json`
+- Example: <https://www.nvaccess.org/addonStore/en/all/2021.2.0.json>
+
+### `GET` All stable
+Get a complete list of the latest stable add-on releases.
+Includes only stable versions
+
+- Format: `https://www.nvaccess.org/addonStore/<language>/stable/<NVDA API Version>.json`
+- Example: <https://www.nvaccess.org/addonStore/en/stable/2021.2.0.json>
+
+### `GET` All beta
+Get a complete list of the latest beta add-on releases.
+Includes only beta versions
+
+- Format: `https://www.nvaccess.org/addonStore/<language>/beta/<NVDA API Version>.json`
+- Example: <https://www.nvaccess.org/addonStore/en/beta/2021.2.0.json>
 
 ## Suffix
 


### PR DESCRIPTION
Now that the addon store has been deployed to production, this PR adds a list of endpoints that will be used by NVDA to poll for the lastest addons.

So that the API that NVDA will use is publicly documented for any NVDA developer to refer to.