### PR TITLE
Add readFeeds 13.0.0 (beta) to NVDA add-ons datastore

### DIFF
--- a/addons/readFeeds/13.0.0.json
+++ b/addons/readFeeds/13.0.0.json
@@ -1,0 +1,29 @@
+{
+	"displayName": "Read Feeds",
+	"publisher": "nvdaes",
+	"description": "Add-on for using NVDA as a feed reader.",
+	"homepage": "https://github.com/nvdaes/readFeeds",
+	"addonId": "readFeeds",
+	"addonVersionName": "13.0.0",
+	"addonVersionNumber": {
+		"major": 13,
+		"minor": 0,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2019,
+		"minor": 3,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2021,
+		"minor": 3,
+		"patch": 1
+	},
+	"channel": "beta",
+	"URL": "https://github.com/nvdaes/readFeeds/releases/download/13.0.0/readFeeds-13.0.0.nvda-addon",
+	"sha256": "a99df63ae5780660b0ed7290c6eb1ec7ed5e635288be8ae0fe716a032976828d",
+	"sourceURL": "https://github.com/nvdaes/readFeeds/",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
+}


### PR DESCRIPTION
Add-on sent mostly to test the store. Channel is beta and this test should pass, i.e., this PR should be automatically merged. Metadata has been validated locally.