### PR TITLE
Add emoticons 14.6 to add-on datastore

### DIFF
--- a/addons/emoticons/14.6.0.json
+++ b/addons/emoticons/14.6.0.json
@@ -1,0 +1,29 @@
+{
+	"displayName": "Emoticons",
+	"publisher": "nvdaes",
+	"description": "Enables the announcement of emoticon names instead of the character Representation.",
+	"homepage": "https://github.com/nvdaes/emoticons",
+	"addonId": "emoticons",
+	"addonVersionName": "14.6",
+	"addonVersionNumber": {
+		"major": 14,
+		"minor": 6,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2019,
+		"minor": 3,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2021,
+		"minor": 3,
+		"patch": 1
+	},
+	"channel": "stable",
+	"URL": "https://github.com/nvdaes/emoticons/releases/download/14.6/emoticons-14.6.nvda-addon",
+	"sha256": "7959b7d43b1a47d907c71dad6638661c5f7bf3f06dbcd9710c8a76e3d4039c9d",
+	"sourceURL": "https://github.com/nvdaes/emoticons/",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
+}


### PR DESCRIPTION
Stable version.
Sorry @Christianlm, I made a mistake skipping 14.5 version. This is for initial testing of NVDA add-on datastore.