### PR TITLE
Add eMule 5.1

### DIFF
--- a/addons/eMule/5.1.0.json
+++ b/addons/eMule/5.1.0.json
@@ -1,0 +1,29 @@
+{
+	"displayName": "eMule",
+	"publisher": "nvdaes",
+	"description": "Improves eMule's accessibility with NVDA.\neMule is a P2P program to search and share files.\nYou can get more information about eMule at\nhttp://www.emule-project.net",
+	"homepage": "https://github.com/nvdaes/emule",
+	"addonId": "eMule",
+	"addonVersionName": "5.1",
+	"addonVersionNumber": {
+		"major": 5,
+		"minor": 1,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2019,
+		"minor": 3,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2021,
+		"minor": 3,
+		"patch": 1
+	},
+	"channel": "stable",
+	"URL": "https://github.com/nvdaes/emule/releases/download/5.1/eMule-5.1.nvda-addon",
+	"sha256": "2fcdb7085a2f50a062b1c4313df9a99ab2cfb0f6bba1c4d35efecfcc27bc44ee",
+	"sourceURL": "https://github.com/nvdaes/emule/",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
+}


### PR DESCRIPTION
The description field expands several lines and in the manifest is between triple quotation marks. To validate the .json file, I have needed to use a unique line with \n delimiters.