### PR TITLE
Check that existing addon submission metadata is only added

### DIFF
--- a/.github/workflows/checkAddonMetadata.yaml
+++ b/.github/workflows/checkAddonMetadata.yaml
@@ -40,6 +40,9 @@ jobs:
               if (Boolean(addonFileName)){
                 throw "Please submit addon releases individually. One file at a time."
               }
+              if (fileData.status === "modified") {
+                throw "Submitted add-ons cannot be modified"
+              }
               addonFileName = filename
             }
             else {

--- a/.github/workflows/checkAddonMetadata.yaml
+++ b/.github/workflows/checkAddonMetadata.yaml
@@ -40,8 +40,8 @@ jobs:
               if (Boolean(addonFileName)){
                 throw "Please submit addon releases individually. One file at a time."
               }
-              if (fileData.status === "modified") {
-                throw "Submitted add-ons cannot be modified"
+              if (fileData.status != "added") {
+                throw "Modifications to submitted add-ons will not be auto-approved"
               }
               addonFileName = filename
             }


### PR DESCRIPTION
When submissions (files with the "addons" directory of this repo) are altered, the automated check should fail. The only approved PRs should be a single added file.

This is in anticipation of enabled automated merging when checks pass.

Used the schema found here for listing pull request files: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files
