### PR TITLE
Update selection of Add-ons

### DIFF
--- a/addons/clipContentsDesigner/16.1.0.json
+++ b/addons/clipContentsDesigner/16.1.0.json
@@ -1,0 +1,29 @@
+{
+	"displayName": "Clip Contents Designer",
+	"publisher": "nvdaes",
+	"description": "Add-on for managing clipboard text.",
+	"homepage": "https://github.com/nvdaes/clipContentsDesigner",
+	"addonId": "clipContentsDesigner",
+	"addonVersionName": "16.1",
+	"addonVersionNumber": {
+		"major": 16,
+		"minor": 1,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2022,
+		"minor": 1,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2022,
+		"minor": 2,
+		"patch": 0
+	},
+	"channel": "stable",
+	"URL": "https://github.com/nvdaes/clipContentsDesigner/releases/download/16.1/clipContentsDesigner-16.1.nvda-addon",
+	"sha256": "27e94fdfc968e9282a482fd3a36d034c118554ddc38c883ec4c986b018e1423e",
+	"sourceURL": "https://github.com/nvdaes/clipContentsDesigner/",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
+}

--- a/addons/cursorLocator/2.0.0.json
+++ b/addons/cursorLocator/2.0.0.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "cursorLocator",
+	"displayName": "Cursor Locator",
+	"URL": "https://github.com/nvdaes/cursorLocator/releases/download/2.0/cursorLocator-2.0.nvda-addon",
+	"description": "Reports cursor positions while typing on multiline edit controls.",
+	"sha256": "5f5df98e24c9d74bcc4509f97f2f6be571cca40ec10fbdab85e454f4eb98d53a",
+	"homepage": "https://github.com/nvdaes/cursorLocator",
+	"addonVersionName": "2.0",
+	"addonVersionNumber": {
+		"major": 2,
+		"minor": 0,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2022,
+		"minor": 1,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2022,
+		"minor": 1,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "nvdaes",
+	"sourceURL": "https://github.com/nvdaes/cursorLocator",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}

--- a/addons/eMule/6.1.0.json
+++ b/addons/eMule/6.1.0.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "eMule",
+	"displayName": "eMule",
+	"URL": "https://github.com/nvdaes/emule/releases/download/6.1/eMule-6.1.nvda-addon",
+	"description": "Improves eMule's accessibility with NVDA.\neMule is a P2P program to search and share files.\nYou can get more information about eMule at\nhttp://www.emule-project.net",
+	"sha256": "42d59e25991eb118e47cbe16e00d3f7d6cd998115b9c5c2973c30de8a61599a5",
+	"homepage": "https://github.com/nvdaes/emule",
+	"addonVersionName": "6.1",
+	"addonVersionNumber": {
+		"major": 6,
+		"minor": 1,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2022,
+		"minor": 1,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2022,
+		"minor": 2,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "nvdaes",
+	"sourceURL": "https://github.com/nvdaes/emule",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}

--- a/addons/emoticons/15.1.0.json
+++ b/addons/emoticons/15.1.0.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "emoticons",
+	"displayName": "Emoticons",
+	"URL": "https://github.com/nvdaes/emoticons/releases/download/15.1/emoticons-15.1.nvda-addon",
+	"description": "Enables the announcement of emoticon names instead of the character Representation.",
+	"sha256": "6f5c7efc5d47edce63d2ec392fc57d3a4e47a4c49a973cd816e9c0d12f026cef",
+	"homepage": "https://github.com/nvdaes/emoticons",
+	"addonVersionName": "15.1",
+	"addonVersionNumber": {
+		"major": 15,
+		"minor": 1,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2022,
+		"minor": 1,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2022,
+		"minor": 2,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "nvdaes",
+	"sourceURL": "https://github.com/nvdaes/emoticons",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}

--- a/addons/readFeeds/14.0.0.json
+++ b/addons/readFeeds/14.0.0.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "readFeeds",
+	"displayName": "Read Feeds",
+	"URL": "https://github.com/nvdaes/readFeeds/releases/download/14.0/readFeeds-14.0.nvda-addon",
+	"description": "Add-on for using NVDA as a feed reader.",
+	"sha256": "14c37e5b59a0ef8b0739e8eb12467fb81601bc24dc63dff2a8241df4c187a95f",
+	"homepage": "https://github.com/nvdaes/readFeeds",
+	"addonVersionName": "14.0",
+	"addonVersionNumber": {
+		"major": 14,
+		"minor": 0,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2019,
+		"minor": 3,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2022,
+		"minor": 2,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "nvdaes",
+	"sourceURL": "https://github.com/nvdaes/readFeeds",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}

--- a/addons/reportPasswords/3.2.0.json
+++ b/addons/reportPasswords/3.2.0.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "reportPasswords",
+	"displayName": "Report Passwords",
+	"URL": "https://github.com/nvdaes/reportPasswords/releases/download/3.2/reportPasswords-3.2.nvda-addon",
+	"description": "When this add-on is installed, NVDA can report the text typed in protected controls such as passwords.",
+	"sha256": "402d1f1ec2dbdc1dfd41d22c56c7a414f5a3ed93786337812da136fa1e7a8d86",
+	"homepage": "https://github.com/nvdaes/reportPasswords",
+	"addonVersionName": "3.2",
+	"addonVersionNumber": {
+		"major": 3,
+		"minor": 2,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2019,
+		"minor": 3,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2022,
+		"minor": 2,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "nvdaes",
+	"sourceURL": "https://github.com/nvdaes/reportPasswords",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}

--- a/addons/reportSymbols/7.3.0.json
+++ b/addons/reportSymbols/7.3.0.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "reportSymbols",
+	"displayName": "Report Symbols",
+	"URL": "https://github.com/nvdaes/reportSymbols/releases/download/7.3/reportSymbols-7.3.nvda-addon",
+	"description": "Allows to listen the typed symbols (non alphanumeric or blank characters), even when the speaking of characters is turned off.",
+	"sha256": "b059c23e917cb8eb9ce4961b66e5e5ad27eeab6238061ee11a21c3af18977d82",
+	"homepage": "https://github.com/nvdaes/reportSymbols",
+	"addonVersionName": "7.3",
+	"addonVersionNumber": {
+		"major": 7,
+		"minor": 3,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2019,
+		"minor": 3,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2022,
+		"minor": 2,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "nvdaes",
+	"sourceURL": "https://github.com/nvdaes/reportSymbols",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}

--- a/addons/soundSplitter/22.3.1.json
+++ b/addons/soundSplitter/22.3.1.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "soundSplitter",
+	"displayName": "Sound Splitter",
+	"URL": "https://github.com/josephsl/soundSplitter/releases/download/22.03/soundSplitter-22.03.1.nvda-addon",
+	"description": "Splits sound from NvDA screen reader and other programs to separate channels",
+	"sha256": "7caa319ef98b0eecc52160c9d49b0f12ca81e86bf70084e97a753143fd5a7918",
+	"homepage": "https://addons.nvda-project.org/",
+	"addonVersionName": "22.03.1",
+	"addonVersionNumber": {
+		"major": 22,
+		"minor": 3,
+		"patch": 1
+	},
+	"minNVDAVersion": {
+		"major": 2021,
+		"minor": 3,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2022,
+		"minor": 1,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "josephsl",
+	"sourceURL": "https://github.com/josephsl/soundSplitter",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}

--- a/addons/wintenApps/22.8.0.json
+++ b/addons/wintenApps/22.8.0.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "wintenApps",
+	"displayName": "Windows App Essentials",
+	"URL": "https://github.com/josephsl/wintenApps/releases/download/22.08/wintenApps-22.08.nvda-addon",
+	"description": "Improving support for various apps and controls on Windows 10 and later",
+	"sha256": "404e593c9b371a192d1d6581080fa01b97e82e34f3ff2098752cad3a1757cb03",
+	"homepage": "https://addons.nvda-project.org/",
+	"addonVersionName": "22.08",
+	"addonVersionNumber": {
+		"major": 22,
+		"minor": 8,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2021,
+		"minor": 3,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2022,
+		"minor": 2,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "josephsl",
+	"sourceURL": "https://github.com/josephsl/wintenApps",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}


### PR DESCRIPTION
Update a handful of add-ons to ensure there are some add-ons compatible with the latest versions of NVDA.

Adding multiple files is typically not supported, and isn't expected to be a common use case. The automated checks (GitHub actions) are expected to fail due to multiple files. If this becomes a common requirement, the validation system could be extended to support multiple files.

Instead, validation has been run locally for each of these files.