### PR TITLE
Windows App Essentials 22.08.1

### DIFF
--- a/addons/wintenApps/22.8.1.json
+++ b/addons/wintenApps/22.8.1.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "wintenApps",
+	"displayName": "Windows App Essentials",
+	"URL": "https://github.com/josephsl/wintenApps/releases/download/22.08/wintenApps-22.08.1.nvda-addon",
+	"description": "Improving support for various apps and controls on Windows 10 and later",
+	"sha256": "ee73751bf4a404cc5ebbe8c32b48b5bfc9fde72c5a8321530f8bb42fee022df4",
+	"homepage": "https://addons.nvda-project.org/",
+	"addonVersionName": "22.08.1",
+	"addonVersionNumber": {
+		"major": 22,
+		"minor": 8,
+		"patch": 1
+	},
+	"minNVDAVersion": {
+		"major": 2021,
+		"minor": 3,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2022,
+		"minor": 3,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "josephsl",
+	"sourceURL": "https://github.com/josephsl/wintenApps",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}


### PR DESCRIPTION
## Changelog:
- Initial support for Windows 10 Version 22H2 and NVDA 2022.3.
