### PR TITLE
Windows App Essentials 23.03

### DIFF
--- a/addons/wintenApps/23.3.0.json
+++ b/addons/wintenApps/23.3.0.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "wintenApps",
+	"displayName": "Windows App Essentials",
+	"URL": "https://github.com/josephsl/wintenApps/releases/download/23.03/wintenApps-23.03.nvda-addon",
+	"description": "Improving support for various apps and controls on Windows 10 and later",
+	"sha256": "eeff4cb46e400d458167ea74e38a5394fa76cd782d0f3bcb5d2285818340fbaa",
+	"homepage": "https://addons.nvda-project.org/",
+	"addonVersionName": "23.03",
+	"addonVersionNumber": {
+		"major": 23,
+		"minor": 3,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2022,
+		"minor": 4,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2023,
+		"minor": 1,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "josephsl",
+	"sourceURL": "https://github.com/josephsl/wintenApps",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 23.02
- Update channel: stable
- NVDA compatibility: 2022.4 and later

### Changelog (mention changes in separate lines starting with dash space)
- Added type information to more areas of the add-on source code.
- Windows 11: NVDA will no longer appear to do nothing or play error tones when using the mouse to review taskbar items at the cost of not announcing position information sometimes.
- Windows 11: NVDA will no longer record information on 22H2 beta builds.
- MSN Weather: Removed "no more weather data" message when arrowing up and down from weather items list.
- Notepad (Windows 11): NVDA will no longer say "back" when retrieving status bar contents in Notepad 11.2301 and later, particularly after opening and closing Notepad settings (Alt+S).

### Additional information
