### PR TITLE
Add-on Updater 23.03 (official add-on ID = addonUpdater)

### DIFF
--- a/addons/addonUpdater/23.3.0.json
+++ b/addons/addonUpdater/23.3.0.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "addonUpdater",
+	"displayName": "Add-on Updater",
+	"URL": "https://github.com/josephsl/addonUpdater/releases/download/23.03/addonUpdater-23.03.nvda-addon",
+	"description": "Proof of concept implementation of add-on update feature (NVDA Core issue 3208)",
+	"sha256": "ec626a1ec6fcf3b01bebea19a6cb18fb6a550fb2c0c3326f52120efd5d46dc61",
+	"homepage": "https://addons.nvda-project.org/",
+	"addonVersionName": "23.03",
+	"addonVersionNumber": {
+		"major": 23,
+		"minor": 3,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2022,
+		"minor": 4,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2023,
+		"minor": 1,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "josephsl",
+	"sourceURL": "https://github.com/josephsl/addonUpdater",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}

--- a/addons/addonUpdater/23.3.1.json
+++ b/addons/addonUpdater/23.3.1.json
@@ -1,15 +1,15 @@
 {
 	"addonId": "addonUpdater",
 	"displayName": "Add-on Updater",
-	"URL": "https://github.com/josephsl/addonUpdater/releases/download/23.03/addonUpdater-23.03.nvda-addon",
+	"URL": "https://github.com/josephsl/addonUpdater/releases/download/23.03/addonUpdater-23.03.1.nvda-addon",
 	"description": "Proof of concept implementation of add-on update feature (NVDA Core issue 3208)",
-	"sha256": "ec626a1ec6fcf3b01bebea19a6cb18fb6a550fb2c0c3326f52120efd5d46dc61",
+	"sha256": "6ffd2a0946aea135ea92a4a7df015ea65b2213e91bc9e9df9f6a96cd814c3ddc",
 	"homepage": "https://addons.nvda-project.org/",
-	"addonVersionName": "23.03",
+	"addonVersionName": "23.03.1",
 	"addonVersionNumber": {
 		"major": 23,
 		"minor": 3,
-		"patch": 0
+		"patch": 1
 	},
 	"minNVDAVersion": {
 		"major": 2022,


### PR DESCRIPTION
NOTE: sets official add-on ID to "addonUpdater", with docs to be updated shortly after. The legacy "nvda32-8" key is kept for compatibility.