### PR TITLE
TeleNVDA 2023.3.1

### DIFF
--- a/addons/TeleNVDA/2023.3.1.json
+++ b/addons/TeleNVDA/2023.3.1.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "TeleNVDA",
+	"displayName": "Tele NVDA remote assistance",
+	"URL": "https://github.com/nvda-es/TeleNVDA/releases/download/2023.3.1/TeleNVDA-2023.3.1.nvda-addon",
+	"description": "Allows remote control of and remote access to another machine. This add-on is based on NVDA Remote.",
+	"sha256": "3cee4e55d176d2f0d785b020956043d2b304ac5a5daee3fa53b9c0cb9651c502",
+	"homepage": "https://github.com/nvda-es/TeleNVDA",
+	"addonVersionName": "2023.3.1",
+	"addonVersionNumber": {
+		"major": 2023,
+		"minor": 3,
+		"patch": 1
+	},
+	"minNVDAVersion": {
+		"major": 2019,
+		"minor": 3,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2023,
+		"minor": 1,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "",
+	"sourceURL": "https://github.com/nvda-es/TeleNVDA",
+	"license": "GPL 2",
+	"licenseURL": "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
+}

--- a/addons/TeleNVDA/2023.3.1.json
+++ b/addons/TeleNVDA/2023.3.1.json
@@ -3,7 +3,7 @@
 	"displayName": "Tele NVDA remote assistance",
 	"URL": "https://github.com/nvda-es/TeleNVDA/releases/download/2023.3.1/TeleNVDA-2023.3.1.nvda-addon",
 	"description": "Allows remote control of and remote access to another machine. This add-on is based on NVDA Remote.",
-	"sha256": "3cee4e55d176d2f0d785b020956043d2b304ac5a5daee3fa53b9c0cb9651c502",
+	"sha256": "56199f39fbc3b82e934a532947951e517edeb73495dedf36ce46cbf86710ca1d",
 	"homepage": "https://github.com/nvda-es/TeleNVDA",
 	"addonVersionName": "2023.3.1",
 	"addonVersionNumber": {


### PR DESCRIPTION
TeleNVDA is a forked version of NVDA Remote maintained by the spanish community. More information is available on the GitHub repository.