### PR TITLE
Resource Monitor 23.02.1 (add-on ID = resourceMonitor)

### DIFF
--- a/addons/resourceMonitor/23.2.1.json
+++ b/addons/resourceMonitor/23.2.1.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "resourceMonitor",
+	"displayName": "Resource Monitor",
+	"URL": "https://github.com/josephsl/resourceMonitor/releases/download/23.02/resourceMonitor-23.02.1.nvda-addon",
+	"description": "A handy resource monitor to report CPU load, memory usage, battery, disk usage status and more.",
+	"sha256": "3bc3557324f8a1841ed140da683f3c178b35b11c73bffc035f28279e8e5f906d",
+	"homepage": "https://addons.nvda-project.org/",
+	"addonVersionName": "23.02.1",
+	"addonVersionNumber": {
+		"major": 23,
+		"minor": 2,
+		"patch": 1
+	},
+	"minNVDAVersion": {
+		"major": 2022,
+		"minor": 4,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2023,
+		"minor": 1,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "josephsl",
+	"sourceURL": "https://github.com/josephsl/resourcemonitor",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}


### PR DESCRIPTION
Add-on migration: add "resourceMonitor" add-on id, serving as the official ID for Resource Monitor add-on.