### PR TITLE
Outlook Extended: camel case

### DIFF
--- a/addons/outlookExtended/1.10.0.json
+++ b/addons/outlookExtended/1.10.0.json
@@ -2,7 +2,7 @@
 	"displayName": "Outlook Extended (legacy)",
 	"publisher": "Cyrille Bougot <cyrille.bougot2@laposte.net>, Ralf Kefferpuetz <ralf.kefferpuetz@elra-consulting.de>",
 	"description": "Extended support and features for Microsoft Outlook:\n- Provide gestures to read and navigate to headers, information bar and attachments in messages, calendar items, tasks.\n- Improve result reading in address book.\n- Vocalize mark as read/unread ctrl+q/ctrl+u commands.",
-	"addonId": "outlookextended",
+	"addonId": "outlookExtended",
 	"addonVersionName": "1.10",
 	"addonVersionNumber": {
 		"major": 1,

--- a/addons/outlookExtended/1.10.1.json
+++ b/addons/outlookExtended/1.10.1.json
@@ -2,7 +2,7 @@
 	"displayName": "Outlook Extended (legacy)",
 	"publisher": "Cyrille Bougot <cyrille.bougot2@laposte.net>, Ralf Kefferpuetz <ralf.kefferpuetz@elra-consulting.de>",
 	"description": "Extended support and features for Microsoft Outlook:\n- Provide gestures to read and navigate to headers, information bar and attachments in messages, calendar items, tasks.\n- Improve result reading in address book.\n- Vocalize mark as read/unread ctrl+q/ctrl+u commands.",
-	"addonId": "outlookextended",
+	"addonId": "outlookExtended",
 	"addonVersionName": "1.10",
 	"addonVersionNumber": {
 		"major": 1,


### PR DESCRIPTION
Rename "outlookextended" to "outlookExtended" (camel case) for folder and addonId.
