### PR TITLE
Supply nvdaAPIVersions.json to validate check

### DIFF
--- a/.github/workflows/checkAddonMetadata.yaml
+++ b/.github/workflows/checkAddonMetadata.yaml
@@ -60,5 +60,11 @@ jobs:
       run: |
         python -m pip install --upgrade wheel
         pip install -r addon-datastore-validation/requirements.txt
+    # TODO: consider migrating nvdaAPIVersions.json to this repo, or its own repo
+    - name: Checkout transformation repo for nvdaAPIVersions.json
+      uses: actions/checkout@v3
+      with:
+        repository: nvaccess/addon-datastore-transform
+        path: transform
     - name: Validate metadata
-      run: addon-datastore-validation/runvalidate ${{steps.getMetadata.outputs.result}}
+      run: addon-datastore-validation/runvalidate ${{steps.getMetadata.outputs.result}} ./transform/nvdaAPIVersions.json


### PR DESCRIPTION
Integrates changes from https://github.com/nvaccess/addon-datastore-validation/pull/17, https://github.com/nvaccess/addon-datastore-validation/issue/16

It may be worth moving nvdaAPIVersions.json to its own repository or this repository.