### PR TITLE
Require the user to manually submit PR from branch

### DIFF
--- a/.github/workflows/checkAddonMetadata.yaml
+++ b/.github/workflows/checkAddonMetadata.yaml
@@ -4,14 +4,12 @@ on:
   pull_request:
     branches:
       - master
-      - removeTools
     paths:
       - addons/**
 
 jobs:
 
   checkMetadata:
-  
     runs-on: windows-latest
     strategy:
       matrix:

--- a/.github/workflows/sendJsonFile.yaml
+++ b/.github/workflows/sendJsonFile.yaml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   check-addon:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     name: Check add-on
     if: github.event.label.name == 'autoSubmissionFromIssue'
     runs-on: windows-latest
@@ -14,7 +18,7 @@ jobs:
     - name: Checkout datastore repo
       uses: actions/checkout@v3
       with:
-        repository: nvdaes/addon-datastore
+        repository: nvaccess/addon-datastore
         ref: master
         path: datastore
     - name: Get data
@@ -40,25 +44,19 @@ jobs:
       run: |
         validation\runcreatejson -f addon.nvda-addon --dir datastore\addons --channel=${{ steps.get-data.outputs.releaseChannel }} --publisher=${{ github.event.sender.login }} --sourceUrl=${{ steps.get-data.outputs.sourceUrl }} --url=${{ steps.get-data.outputs.downloadUrl }} --licName="${{ steps.get-data.outputs.licenseName }}" --licUrl=${{ steps.get-data.outputs.licenseURL }}
       shell: cmd
-    - name: Create Pull Request
-      id: cpr
-      uses: peter-evans/create-pull-request@v4
+    - name: Commit and push
+      run: |
+        cd datastore
+        git checkout -b ${{ github.event.sender.login }}${{ steps.get-data.outputs.issueNumber }}
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add .
+        git commit -m "${{ steps.get-data.outputs.issueTitle }}" -m "Closes #${{ steps.get-data.outputs.issueNumber }}"
+        git push --set-upstream origin ${{ github.event.sender.login }}${{ steps.get-data.outputs.issueNumber }}
+    - name: Add comment
+      uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae
       with:
-        token: ${{secrets.PR_ACCESS_TOKEN }}
-        path: datastore
-        title: ${{ steps.get-data.outputs.issueTitle }}
-        branch: ${{ github.event.sender.login }}${{ steps.get-data.outputs.issueNumber }}
-        commit-message: ${{ steps.get-data.outputs.issueTitle }}
-        body: "Closes issue #${{ steps.get-data.outputs.issueNumber }}"
-        author: github-actions <github-actions@github.com>
-    - name: Enable Pull Request Automerge
-      if: steps.cpr.outputs.pull-request-operation == 'created'
-      uses: peter-evans/enable-pull-request-automerge@v2
-      with:
-        token: ${{ secrets.PR_ACCESS_TOKEN }}
-        pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-    - name: Close Issue
-      uses: peter-evans/close-issue@v2
-      with:
-        issue-number: ${{ steps.get-data.outputs.issueNumber }}
-        comment: Auto-closing issue
+        issue-number: ${{ github.event.issue.number }}
+        body: |
+          Submission has been prepared.
+          Use [this link](https://github.com/nvaccess/addon-datastore/pull/new/${{ github.event.sender.login }}${{ steps.get-data.outputs.issueNumber }}) to create a pull request submission from this issue.

--- a/docs/submitters/submissionGuide.md
+++ b/docs/submitters/submissionGuide.md
@@ -14,7 +14,9 @@ You can create this manually, or generate this by submitting an issue.
 ### Submit from an issue form
 1. Select ["Add-on registration" from the new issue options](https://github.com/nvaccess/addon-datastore/issues/new/choose).
 1. Fill out and submit the issue form.
-1. A PR should automatically open.
+1. Soon after, a link will be posted in the comments of your issue.
+This link opens a pull request with your automatically generated submission.
+GitHub actions requires an author to manually submit a PR for it to be auto-approved.
 1. If the PR fails to auto-merge, re-submit the auto-generated JSON file by following the "Manual file creation" steps.
 
 ### Manual file creation

--- a/docs/submitters/submissionGuide.md
+++ b/docs/submitters/submissionGuide.md
@@ -17,7 +17,6 @@ You can create this manually, or generate this by submitting an issue.
 1. Soon after, a link will be posted in the comments of your issue.
 This link opens a pull request with your automatically generated submission.
 GitHub actions requires an author to manually submit a PR for it to be auto-approved.
-1. If the PR fails to auto-merge, re-submit the auto-generated JSON file by following the "Manual file creation" steps.
 
 ### Manual file creation
 1. Fork the `addon-datastore` repository


### PR DESCRIPTION
GitHub actions do not allow one action to indirectly trigger another action.

As such, to fully automate the submission process, we must do the following:

- Run the full PR validation checks using the issue form workflow
- Push commit straight to master, rather than open a PR
- Run the transformation to views after committing to master.

This requires making our 3 step workflow (issue to PR to transformation) into a single GitHub action.

In the mean time, we can encourage users to manually create the PR from a generated branch, and then manually merge approved PRs.

This PR introduces adding a comment with a link to create a PR, rather than creating a PR automatically and attempting to turn on auto-merge