### PR TITLE
Windows App Essentials 20230310dev

### DIFF
--- a/addons/wintenApps/20230310.0.0.json
+++ b/addons/wintenApps/20230310.0.0.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "wintenApps",
+	"displayName": "Windows App Essentials",
+	"URL": "https://github.com/josephsl/wintenApps/releases/download/23.03/wintenApps-20230310-dev.nvda-addon",
+	"description": "Improving support for various apps and controls on Windows 10 and later",
+	"sha256": "f169698c5d1ed671b636b0069395582c1422147aef3317b2c6dd129f926c28a7",
+	"homepage": "https://addons.nvda-project.org/",
+	"addonVersionName": "20230310-dev",
+	"addonVersionNumber": {
+		"major": 20230310,
+		"minor": 0,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2022,
+		"minor": 4,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2023,
+		"minor": 1,
+		"patch": 0
+	},
+	"channel": "dev",
+	"publisher": "josephsl",
+	"sourceURL": "https://github.com/josephsl/wintenApps",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}


### PR DESCRIPTION
Windows App Essentials March 10 dev snapshot:

* Readme: added notes on Windows Insider canary channel.
This is the first dev channel build to test add-on store facility.