### PR TITLE
Improve submission process

### DIFF
--- a/.github/ISSUE_TEMPLATE/registerAddon.yml
+++ b/.github/ISSUE_TEMPLATE/registerAddon.yml
@@ -27,6 +27,13 @@ body:
     placeholder: https://github.com/username/repo/
   validations:
     required: true
+- type: input
+  id: publisher
+  attributes:
+    label: Publisher
+    description: The name of the individual, group, or company responsible for the addon.
+  validations:
+    required: true
 - type: dropdown
   id: channel
   attributes:
@@ -43,8 +50,10 @@ body:
   id: license-name
   attributes:
     label: License Name
-    description: What license is this add-on released under?
+    description: The license that this add-on is released under.
     value: GPL v2
+  validations:
+    required: true
 - type: input
   id: license-url
   attributes:

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -57,7 +57,6 @@ jobs:
         repository: nvaccess/addon-datastore-validation
         path: addon-datastore-validation
         submodules: true
-        ref: outputValdiationErros
     - name: Install addon-datastore-validation dependencies
       run: |
         python -m pip install --upgrade wheel

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -79,7 +79,7 @@ jobs:
       with:
         source_ref: ${{ inputs.headRef }}
         target_branch: master
-        commit_message_template: '[Automated] Merged ${{ steps.getMetadata.outputs.result }} (${{ inputs.pullRequestNumber }}) into master'
+        commit_message_template: '[Automated] Merged ${{ steps.getMetadata.outputs.result }} (#${{ inputs.pullRequestNumber }}) into master'
   call-workflow:
     needs: checkMetadata
     uses: ./.github/workflows/transformDataToViews.yml

--- a/.github/workflows/getData.js
+++ b/.github/workflows/getData.js
@@ -13,6 +13,7 @@ module.exports = ({context, core}) => {
 	const header3Prefix = "###"
 	const dlTitleMd = "### Download URL"
 	const sourceUrlMd = "### Source URL"
+	const publisherMd = "### Publisher"
 	const channelMd = "### Channel"
 	const licenseMd = "### License Name"
 	const licenseUrlMd = "### License URL"
@@ -24,6 +25,8 @@ module.exports = ({context, core}) => {
 	core.setOutput('downloadUrl', downloadUrl)
 	const sourceUrl = body.split(sourceUrlMd)[1].split(header3Prefix)[0].trim()
 	core.setOutput('sourceUrl', sourceUrl)
+	const publisherUrl = body.split(publisherMd)[1].split(header3Prefix)[0].trim()
+	core.setOutput('publisher', publisherUrl)
 	const releaseChannel = body.split(channelMd)[1].split(header3Prefix)[0].trim()
 	core.setOutput('releaseChannel', releaseChannel)
 	const licenseName = body.split(licenseMd)[1].split(header3Prefix)[0].trim()

--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -45,16 +45,15 @@ jobs:
       run: curl --location --output addon.nvda-addon ${{ steps.get-data.outputs.downloadUrl }}
     - name: Create JSON submission from issue
       run: |
-        validation\runcreatejson ^
-        -f addon.nvda-addon ^
-        --dir datastore\addons ^
-        --channel=${{ steps.get-data.outputs.releaseChannel }} ^
-        --publisher=${{ github.event.sender.login }} ^
-        --sourceUrl=${{ steps.get-data.outputs.sourceUrl }} ^
-        --url=${{ steps.get-data.outputs.downloadUrl }} ^
-        --licName="${{ steps.get-data.outputs.licenseName }}" ^
-        --licUrl=${{ steps.get-data.outputs.licenseURL }} ^
-      shell: cmd
+        validation/runcreatejson `
+        -f addon.nvda-addon `
+        --dir datastore\addons `
+        --channel=${{ steps.get-data.outputs.releaseChannel }} `
+        --publisher=${{ steps.get-data.outputs.publisher }} `
+        --sourceUrl=${{ steps.get-data.outputs.sourceUrl }} 
+        --url=${{ steps.get-data.outputs.downloadUrl }} `
+        --licName="${{ steps.get-data.outputs.licenseName }}" `
+        --licUrl=${{ steps.get-data.outputs.licenseURL }} `
     - name: Create Pull Request
       id: cpr
       uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/transformDataToViews.yml
+++ b/.github/workflows/transformDataToViews.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         repository: nvaccess/addon-datastore
         path: data
+        fetch-depth: 0
     - name: Checkout views branch into separate folder
       uses: actions/checkout@v3
       with:

--- a/addons/clipContentsDesigner/17.1.0.json
+++ b/addons/clipContentsDesigner/17.1.0.json
@@ -22,7 +22,7 @@
 		"patch": 0
 	},
 	"channel": "stable",
-	"publisher": "seanbudd",
+	"publisher": "nvdaes",
 	"sourceURL": "https://github.com/nvdaes/clipContentsDesigner/",
 	"license": "GPL v2",
 	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"

--- a/addons/controlUsageAssistant/2023.3.9.json
+++ b/addons/controlUsageAssistant/2023.3.9.json
@@ -22,7 +22,7 @@
 		"patch": 0
 	},
 	"channel": "stable",
-	"publisher": "seanbudd",
+	"publisher": "nvdaes",
 	"sourceURL": "https://github.com/nvdaes/controlUsageAssistant/",
 	"license": "GPL v2",
 	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"

--- a/addons/enhancedAnnotations/2.0.0.json
+++ b/addons/enhancedAnnotations/2.0.0.json
@@ -22,7 +22,7 @@
 		"patch": 0
 	},
 	"channel": "stable",
-	"publisher": "seanbudd",
+	"publisher": "nvdaes",
 	"sourceURL": "https://github.com/nvdaes/enhancedAnnotations/",
 	"license": "GPL v2",
 	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"

--- a/addons/sayProductNameAndVersion/2023.3.0.json
+++ b/addons/sayProductNameAndVersion/2023.3.0.json
@@ -12,8 +12,8 @@
 		"patch": 0
 	},
 	"minNVDAVersion": {
-		"major": 2017,
-		"minor": 3,
+		"major": 0,
+		"minor": 0,
 		"patch": 0
 	},
 	"lastTestedVersion": {

--- a/addons/sayProductNameAndVersion/2023.3.0.json
+++ b/addons/sayProductNameAndVersion/2023.3.0.json
@@ -1,7 +1,7 @@
 {
 	"addonId": "sayProductNameAndVersion",
 	"displayName": "Say Product Name and Version",
-	"URL": "https://github.com/Nardol/SayProductNameAndVersion/releases/download/2023.3/sayProductNameAndVersion-2023.3.nvda-addon",
+	"URL": "https://github.com/opensourcesys/SayProductNameAndVersion/releases/download/2023.3/sayProductNameAndVersion-2023.3.nvda-addon",
 	"description": "Say product name and version of the application which ownes the focused window.\nShortcut: Shift+NVDA+V",
 	"sha256": "04777a1303f7295be4f9ef683ae311c66d83781a166fe92c2383657fe54779c3",
 	"homepage": "None",
@@ -22,8 +22,8 @@
 		"patch": 0
 	},
 	"channel": "stable",
-	"publisher": "seanbudd",
-	"sourceURL": "https://github.com/Nardol/SayProductNameAndVersion",
+	"publisher": "opensourcesys",
+	"sourceURL": "https://github.com/opensourcesys/SayProductNameAndVersion",
 	"license": "GPL v2",
 	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
 }

--- a/docs/submitters/submissionGuide.md
+++ b/docs/submitters/submissionGuide.md
@@ -33,6 +33,7 @@ Descriptions for the fields of JSON schema can be found in [jsonMetadata.md](./j
 Refer to [addon-datastore-validation](https://github.com/nvaccess/addon-datastore-validation) for more information on automated checks.
 1. If the checks pass, the PR should be merged automatically.
 1. If the checks fail, a comment should be added to the pull request outlining the failure.
-You may need to update your add-on manifest and resubmit the issue form.
+To address the issues, resubmit the issue form or manual pull request.
+You may need to also update your add-on manifest.
 Descriptions for the fields of JSON schema can be found in [jsonMetadata.md](./jsonMetadata.md).
 1. When the PR is merged the add-on becomes available in the store.

--- a/docs/submitters/submissionGuide.md
+++ b/docs/submitters/submissionGuide.md
@@ -14,11 +14,25 @@ You can create this manually, or generate this by submitting an issue.
 ### Submit from an issue form
 1. Select ["Add-on registration" from the new issue options](https://github.com/nvaccess/addon-datastore/issues/new/choose).
 1. Fill out and submit the issue form.
-Detailed descriptions for the fields of JSON schema can be found in [jsonMetadata.md](./jsonMetadata.md).
+This will create an issue with a summary of your submission.
+The form and your add-on's manifest are used to create a JSON file.
+This JSON file is submitted as a pull request to the repository.
 
-## After submitting your issue
-1. Automated checks to validate the submission will complete.
+### Manual file creation
+1. Fork the `addon-datastore` repository
+1. On a new branch, copy the `_template_addon_release.json` file. 
+	- Rename and move the file to `addons/<addonID>/<version>.json`
+	- `<addonID>` is the ID of the add-on. This should match the `name` field in the add-on manifest, e.g. "speechPlayer"
+	- `<version>` is the add-on version in the form: `Major.Minor.Patch` e.g. "2.4.1"
+1. Fill out the template.
+Descriptions for the fields of JSON schema can be found in [jsonMetadata.md](./jsonMetadata.md).
+1. Create a PR to merge your branch into master on the `addon-datastore` repository.
+
+## After submitting your add-on version file
+1. Automated checks are ran to validate the submission.
 Refer to [addon-datastore-validation](https://github.com/nvaccess/addon-datastore-validation) for more information on automated checks.
 1. If the checks pass, the PR should be merged automatically.
-A comment will be posted on the pull request explaining the validation errors.
+1. If the checks fail, a comment should be added to the pull request outlining the failure.
+You may need to update your add-on manifest and resubmit the issue form.
+Descriptions for the fields of JSON schema can be found in [jsonMetadata.md](./jsonMetadata.md).
 1. When the PR is merged the add-on becomes available in the store.


### PR DESCRIPTION
Closes #220
Closes #219

In tandem with https://github.com/nvaccess/addon-datastore-validation/pull/19

* Adds "publisher" to the issue submission form, instead of assuming it is the username of the GitHub issue submitter.
* Ensure the submission fails if the JSON file fails to be created (failure example: https://github.com/nvaccess/addon-datastore/actions/runs/4495828472)
* updates some add-on metadata to the correct publisher
* Updates the submission steps
* Fixes a caching problem described in #219 
