### PR TITLE
Post a comment if the file check fails

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -31,26 +31,13 @@ jobs:
         pullRequestNumber: ${{ inputs.pullRequestNumber }}
       with:
         script: |
-          const url = "GET /repos/nvaccess/addon-datastore/pulls/" + process.env.pullRequestNumber + "/files" 
-          const result = await github.request(url)
-          var addonFileName
-          const changedFiles = result.data
-          for (fileData of changedFiles) {
-            const filename = fileData.filename
-            if (filename.startsWith("addons")) {
-              if (Boolean(addonFileName)){
-                throw "Please submit addon releases individually. One file at a time."
-              }
-              if (fileData.status != "added") {
-                throw "Modifications to submitted add-ons will not be auto-approved"
-              }
-              addonFileName = filename
-            }
-            else {
-              throw "Non-addon-submission files updated"
-            }
-          }
-          return addonFileName
+          return require('./datastore/.github/workflows/checkFilesChanged.js')
+    - name: Post file check errors as comment
+      if: failure()
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        issue-number: ${{ inputs.pullRequestNumber }}
+        body: ${{ steps.getMetadata.outputs.errors }}
     - name: Checkout validate repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/checkFilesChanged.js
+++ b/.github/workflows/checkFilesChanged.js
@@ -1,0 +1,26 @@
+module.exports = await getAddonFileName()
+
+const url = "GET /repos/nvaccess/addon-datastore/pulls/" + process.env.pullRequestNumber + "/files" 
+
+async function getAddonFileName() {
+	const result = await github.request(url)
+	var addonFileName
+	const changedFiles = result.data
+	for (fileData of changedFiles) {
+		const filename = fileData.filename
+		if (filename.startsWith("addons")) {
+			if (Boolean(addonFileName)){
+				throw "Please submit addon releases individually. One file at a time."
+			}
+			if (fileData.status != "added") {
+				throw "Modifications to submitted add-ons will not be auto-approved"
+			}
+			addonFileName = filename
+		}
+		else {
+			throw "Non-addon-submission files updated. This will not be auto-approved."
+		}
+	}
+	return addonFileName
+}
+


### PR DESCRIPTION
auto-submissions can fail to be auto-approved:
- if add-on files are modified
- multiple files are submitted
- or files that are not add-on files are changed

These errors are different to typical validation errors, but should be posted as a comment as well, otherwise authors may be confused as to why their submission failed.