### PR TITLE
When transforming to views, always use master branch data

### DIFF
--- a/.github/workflows/transformDataToViews.yml
+++ b/.github/workflows/transformDataToViews.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         repository: nvaccess/addon-datastore
         path: data
-        fetch-depth: 0
+        ref: master
     - name: Checkout views branch into separate folder
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Should close #219
https://github.com/actions/checkout/issues/439#issuecomment-1464126822 encourages setting the ref explicitly to always pull the latest data from the ref.
When performing the transformation to views, we always want to use master data, so it is safer to set the ref unambiguously, instead of using the inherited reference (which may come from a different branch/commit).