### PR TITLE
Document how to receive failure feedback for a manual PR

### DIFF
--- a/docs/submitters/jsonMetadata.md
+++ b/docs/submitters/jsonMetadata.md
@@ -46,6 +46,7 @@ Example:
 
 ### addonVersionName
 The addon version being released.
+Should be in the form "<major>.<minor>.<patch>".
 Must match the version in the addon manifest and the file name for the submission.
 
 Example: `21.6.0`.

--- a/docs/submitters/jsonMetadata.md
+++ b/docs/submitters/jsonMetadata.md
@@ -46,7 +46,7 @@ Example:
 
 ### addonVersionName
 The addon version being released.
-Should be in the form "<major>.<minor>.<patch>".
+Should be in the form "`<major>.<minor>.<patch>`".
 Must match the version in the addon manifest and the file name for the submission.
 
 Example: `21.6.0`.

--- a/docs/submitters/jsonMetadata.md
+++ b/docs/submitters/jsonMetadata.md
@@ -67,9 +67,8 @@ The English description of the addon that will be displayed for the addon.
 Example: `"Makes doing XYZ easier"`
 
 ### homepage
-Optional.
 If the addon has a homepage where users can get more information about the addon, you can specify it here.
-Must match the url in the addon manifest.
+Must match the url in the addon manifest, which is optional.
 
 Example: `"https://github.com/nvaccess/addon-datastore"`
 

--- a/docs/submitters/submissionGuide.md
+++ b/docs/submitters/submissionGuide.md
@@ -37,7 +37,7 @@ Descriptions for the fields of JSON schema can be found in [jsonMetadata.md](./j
 Refer to [addon-datastore-validation](https://github.com/nvaccess/addon-datastore-validation) for more information on automated checks.
 1. If the checks fail, the PR will not be automatically merged.
 You can check [the GitHub actions log](https://github.com/nvaccess/addon-datastore/actions/workflows/checkPullRequest.yml?query=event%3Apull_request+is%3Afailure) to find more information on the failure.
-To address the issues, resubmit the issue form.
+To address the issues, update the pull request.
 You may need to also update your add-on manifest.
 1. If the checks pass, the PR should be merged automatically.
 The add-on should soon become available in the store.

--- a/docs/submitters/submissionGuide.md
+++ b/docs/submitters/submissionGuide.md
@@ -12,10 +12,17 @@ Descriptions for the fields of the JSON schema can be found in [jsonMetadata.md]
 ### Submit from an issue form
 1. Select ["Add-on registration" from the new issue options](https://github.com/nvaccess/addon-datastore/issues/new/choose).
 1. Fill out and submit the issue form.
-
 This will create an issue with a summary of your submission.
 The issue form and the add-on's manifest are used to create a JSON file.
 This JSON file is submitted as a pull request to the repository.
+1. Automated checks are ran to validate the submission.
+Refer to [addon-datastore-validation](https://github.com/nvaccess/addon-datastore-validation) for more information on automated checks.
+1. If the checks fail, a comment should be added to the pull request outlining the failure.
+To address the issues, resubmit the issue form.
+You may need to also update your add-on manifest.
+Descriptions for the fields of the JSON schema can be found in [jsonMetadata.md](./jsonMetadata.md).
+1. If the checks pass, the PR should be merged automatically.
+The add-on should soon become available in the store.
 
 ### Manual file creation
 1. Fork the `addon-datastore` repository
@@ -26,14 +33,12 @@ This JSON file is submitted as a pull request to the repository.
 1. Fill out the template.
 Descriptions for the fields of JSON schema can be found in [jsonMetadata.md](./jsonMetadata.md).
 1. Create a PR to merge your branch into master on the `addon-datastore` repository.
-
-## After submitting your add-on version file
 1. Automated checks are ran to validate the submission.
 Refer to [addon-datastore-validation](https://github.com/nvaccess/addon-datastore-validation) for more information on automated checks.
-1. If the checks fail, a comment should be added to the pull request outlining the failure.
-To address the issues, resubmit the issue form or manual pull request.
+1. If the checks fail, the PR will not be automatically merged.
+You can check [the GitHub actions log](https://github.com/nvaccess/addon-datastore/actions/workflows/checkPullRequest.yml?query=event%3Apull_request+is%3Afailure) to find more information on the failure.
+To address the issues, resubmit the issue form.
 You may need to also update your add-on manifest.
-Descriptions for the fields of the JSON schema can be found in [jsonMetadata.md](./jsonMetadata.md).
 1. If the checks pass, the PR should be merged automatically.
 The add-on should soon become available in the store.
 


### PR DESCRIPTION
Unfortunately GitHub actions does not allow commenting on PRs created from forks.
If an author is submitting from a fork, it can be assumed they have some technical knowledge.
As such, this is not a huge issue as information on the failure of their submission can be found in the GitHub actions log.

This PR updates the documentation to encourage manual submitters to check the GitHub actions log for failure information