### PR TITLE
Update NVDA Remote

### DIFF
--- a/addons/remote/2.5.0.json
+++ b/addons/remote/2.5.0.json
@@ -1,8 +1,8 @@
 {
-	"displayName": "Remote Support (legacy)",
+	"displayName": "Remote Support",
 	"publisher": "Tyler Spivey <tspivey@pcdesk.net>, Christopher Toth <q@q-continuum.net>",
 	"description": "Allows remote control of and remote access to another machine.",
-	"addonId": "nvdaremote",
+	"addonId": "remote",
 	"addonVersionName": "2.5",
 	"addonVersionNumber": {
 		"major": 2,

--- a/addons/remote/2.6.2.json
+++ b/addons/remote/2.6.2.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "remote",
+	"displayName": "Remote Support",
+	"URL": "https://github.com/NVDARemote/NVDARemote/releases/download/v2.6.2/remote-2.6.2.nvda-addon",
+	"description": "Allows remote control of and remote access to another machine.",
+	"sha256": "033b13b9099aea735f426f09e4a3bb1db3a789000a0b15fc827a97f314687af5",
+	"homepage": "https://NVDARemote.com",
+	"addonVersionName": "2.6.2",
+	"addonVersionNumber": {
+		"major": 2,
+		"minor": 6,
+		"patch": 2
+	},
+	"minNVDAVersion": {
+		"major": 2019,
+		"minor": 3,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2023,
+		"minor": 1,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "Tyler Spivey <tspivey@pcdesk.net>, Christopher Toth <q@q-continuum.net>",
+	"sourceURL": "https://github.com/nvdaremote/nvdaremote",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}


### PR DESCRIPTION
This PR changes the ID of NVDA Remote from nvdaremote to remote, adds version 2.6.2, removes legacy from the display name of 2.5.0 and also updates its ID.