### PR TITLE
Integrate validating manifest

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         script: |
           const getAddonFilename = require('./.github/workflows/checkFilesChanged.js')
-          const url = "GET /repos/nvaccess/addon-datastore/pulls/" + process.env.pullRequestNumber + "/files" 
+          const url = "GET /repos/" + process.env.GITHUB_REPOSITORY + "/pulls/" + process.env.pullRequestNumber + "/files" 
           const result = await github.request(url)
           return getAddonFilename(result.data)
     - name: Checkout validate repo

--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -21,7 +21,6 @@ jobs:
     - name: Checkout datastore repo
       uses: actions/checkout@v3
       with:
-        repository: nvaccess/addon-datastore
         ref: master
         path: datastore
     - name: Get data
@@ -41,6 +40,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.8
+    - name: Create validation errors file
+      run: echo "" > validationErrors.md
     - name: Download add-on
       run: curl --location --output addon.nvda-addon ${{ steps.get-data.outputs.downloadUrl }}
     - name: Create JSON submission from issue
@@ -48,12 +49,19 @@ jobs:
         validation/runcreatejson `
         -f addon.nvda-addon `
         --dir datastore\addons `
+        --output .\validationErrors.md `
         --channel=${{ steps.get-data.outputs.releaseChannel }} `
         --publisher="${{ steps.get-data.outputs.publisher }}" `
         --sourceUrl=${{ steps.get-data.outputs.sourceUrl }} `
         --url=${{ steps.get-data.outputs.downloadUrl }} `
         --licName="${{ steps.get-data.outputs.licenseName }}" `
         --licUrl=${{ steps.get-data.outputs.licenseURL }}
+    - name: Post validation errors as comment
+      if: failure()
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        issue-number: ${{ github.event.issue.number }}
+        body-file: ./validationErrors.md
     - name: Create Pull Request
       id: cpr
       uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/transformDataToViews.yml
+++ b/.github/workflows/transformDataToViews.yml
@@ -21,13 +21,11 @@ jobs:
     - name: Checkout addon data
       uses: actions/checkout@v3
       with:
-        repository: nvaccess/addon-datastore
         path: data
         ref: master
     - name: Checkout views branch into separate folder
       uses: actions/checkout@v3
       with:
-        repository: nvaccess/addon-datastore
         path: views
         ref: views
     - name: Checkout transformation repo


### PR DESCRIPTION
Integrates changes from https://github.com/nvaccess/addon-datastore-validation/pull/29

This has been tested with this issue: https://github.com/nvaccess/addon-datastore-staging/issues/1

Removes references to the `addon-datastore` repo.
This means that a fork of this repository will automatically use the fork for actions.
This allows for easier testing using [nvaccess/addon-datastore-staging](https://github.com/nvaccess/addon-datastore-staging)