### PR TITLE
Add quotes around submission input to prevent parsing issues

### DIFF
--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -36,6 +36,7 @@ jobs:
         repository: nvaccess/addon-datastore-validation
         submodules: true
         path: validation
+        ref: convertPs
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
@@ -43,19 +44,21 @@ jobs:
     - name: Create validation errors file
       run: echo "" > validationErrors.md
     - name: Download add-on
-      run: curl --location --output addon.nvda-addon ${{ steps.get-data.outputs.downloadUrl }}
+      # wrap all user input in quotations to prevent RCE e.g. www.example.com/&rm -rf
+      run: curl --location --output addon.nvda-addon "${{ steps.get-data.outputs.downloadUrl }}"
     - name: Create JSON submission from issue
+      # wrap all user input in quotations to prevent RCE e.g. www.example.com/&rm -rf
       run: |
         validation/runcreatejson `
         -f addon.nvda-addon `
         --dir datastore\addons `
         --output .\validationErrors.md `
-        --channel=${{ steps.get-data.outputs.releaseChannel }} `
-        --publisher="${{ steps.get-data.outputs.publisher }}" `
-        --sourceUrl=${{ steps.get-data.outputs.sourceUrl }} `
-        --url=${{ steps.get-data.outputs.downloadUrl }} `
-        --licName="${{ steps.get-data.outputs.licenseName }}" `
-        --licUrl=${{ steps.get-data.outputs.licenseURL }}
+        --channel='"${{ steps.get-data.outputs.releaseChannel }}"' `
+        --publisher='"${{ steps.get-data.outputs.publisher }}"' `
+        --sourceUrl='"${{ steps.get-data.outputs.sourceUrl }}"' `
+        --url='"${{ steps.get-data.outputs.downloadUrl }}"' `
+        --licName='"${{ steps.get-data.outputs.licenseName }}"' `
+        --licUrl='"${{ steps.get-data.outputs.licenseURL }}"'
     - name: Post validation errors as comment
       if: failure()
       uses: peter-evans/create-or-update-comment@v2

--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -36,7 +36,6 @@ jobs:
         repository: nvaccess/addon-datastore-validation
         submodules: true
         path: validation
-        ref: convertPs
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
### summary of issue

#992 failed without feedback to the user

This is because the download failed, due to an ampersand in the query parameters, causing the end of the URL to be interpreted as a separate command.
This is a minor security risk, as it could cause remote code injection.

Additionally, users should be alerted as to why their download has failed, instead of failing silently.

### Dev process

PowerShell has a bug with stripping quotes when passing to batch scripts (https://github.com/PowerShell/PowerShell/issues/15250).
Additionally, no validation error is written to file if the downloaded file was not a valid zip file.
Refer to https://github.com/nvaccess/addon-datastore-validation/pull/31 where these issues are fixed.

### testing
See example https://github.com/nvaccess/addon-datastore-staging/issues/11 where a comment was successfully posted and urls were successfully quoted via [this action run](https://github.com/nvaccess/addon-datastore-staging/actions/runs/5374393769/jobs/9749706966)