### PR TITLE
Support translations: remove lang code from transform

### DIFF
--- a/.github/workflows/regenerateTranslations.yml
+++ b/.github/workflows/regenerateTranslations.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+        path: datastore
     - name: Create validation errors file
       run: echo "" > validationErrors.md
     - name: Checkout validate repo
@@ -30,7 +32,7 @@ jobs:
       run: |
         validation/regenerateTranslations `
         --dir datastore\addons `
-        --output .\validationErrors.md
+        --output validationErrors.md
     - name: Commit & Push changes
       uses: actions-js/push@v1.4
       with:
@@ -41,7 +43,8 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: validationErrors
-        path: ./validationErrors.md
+        path: validationErrors.md
+        directory: datastore
   call-workflow:
     needs: regenerateTranslations
     uses: ./.github/workflows/transformDataToViews.yml

--- a/.github/workflows/regenerateTranslations.yml
+++ b/.github/workflows/regenerateTranslations.yml
@@ -35,6 +35,7 @@ jobs:
       uses: actions-js/push@v1.4
       with:
         message: '[Automated] Regenerate translations ${date}'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload validation errors as artifact
       if: failure()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/regenerateTranslations.yml
+++ b/.github/workflows/regenerateTranslations.yml
@@ -39,6 +39,7 @@ jobs:
         message: '[Automated] Regenerate translations ${date}'
         github_token: ${{ secrets.GITHUB_TOKEN }}
         directory: datastore
+        branch: master
     - name: Upload validation errors as artifact
       if: failure()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/regenerateTranslations.yml
+++ b/.github/workflows/regenerateTranslations.yml
@@ -38,13 +38,13 @@ jobs:
       with:
         message: '[Automated] Regenerate translations ${date}'
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        directory: datastore
     - name: Upload validation errors as artifact
       if: failure()
       uses: actions/upload-artifact@v3
       with:
         name: validationErrors
         path: validationErrors.md
-        directory: datastore
   call-workflow:
     needs: regenerateTranslations
     uses: ./.github/workflows/transformDataToViews.yml

--- a/.github/workflows/regenerateTranslations.yml
+++ b/.github/workflows/regenerateTranslations.yml
@@ -1,0 +1,46 @@
+name: Regenerate translations for all add-ons
+
+on:
+  workflow_dispatch:
+
+jobs:
+  regenerateTranslations:
+    permissions:
+      contents: write
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: [ 3.11 ]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Create validation errors file
+      run: echo "" > validationErrors.md
+    - name: Checkout validate repo
+      uses: actions/checkout@v3
+      with:
+        repository: nvaccess/addon-datastore-validation
+        path: validation
+        submodules: true
+    - name: Install addon-datastore-validation dependencies
+      run: |
+        python -m pip install --upgrade wheel
+        pip install -r validation/requirements.txt
+    - name: Regenerate translations
+      run: |
+        validation/regenerateTranslations `
+        --dir datastore\addons `
+        --output .\validationErrors.md
+    - name: Commit & Push changes
+      uses: actions-js/push@v1.4
+      with:
+        message: '[Automated] Regenerate translations ${date}'
+    - name: Upload validation errors as artifact
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: validationErrors
+        path: ./validationErrors.md
+  call-workflow:
+    needs: regenerateTranslations
+    uses: ./.github/workflows/transformDataToViews.yml

--- a/.github/workflows/transformDataToViews.yml
+++ b/.github/workflows/transformDataToViews.yml
@@ -44,9 +44,9 @@ jobs:
         cd transform
         pip install -r requirements.txt
         # empty the views git folder directory 
-        Try { Remove-Item ../views/views/en/ -Recurse -ErrorAction stop }
+        Try { Remove-Item ../views/views/ -Recurse -ErrorAction stop }
         Catch [System.Management.Automation.ItemNotFoundException] { $null }
-        python -m src.transform --loglevel DEBUG nvdaAPIVersions.json ../data/addons ../views/views/en
+        python -m src.transform --loglevel DEBUG nvdaAPIVersions.json ../data/addons ../views/views
     - name: Copy files
       run: |
         copy ./transform/nvdaAPIVersions.json ./views/nvdaAPIVersions.json


### PR DESCRIPTION
Adds a workflow to regenerate translations of all add-ons in the repository

Related PRs to finalize localisation support:
- [ ] https://github.com/nvaccess/addon-datastore-transform/pull/23
- [ ] https://github.com/nvaccess/addon-datastore-validation/pull/32

Tested end-to-end, to generate the following views: https://github.com/nvaccess/addon-datastore-staging/tree/views/views