### PR TITLE
Use concurrency to avoid delay of transformation for undefined time

### DIFF
--- a/.github/workflows/transformDataToViews.yml
+++ b/.github/workflows/transformDataToViews.yml
@@ -6,6 +6,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+concurrency:
+  group: transform
+  cancel-in-progress: true
+
 jobs:
   transformAndPush:
     runs-on: windows-latest


### PR DESCRIPTION
Fixes #1138 

### Summary of the issue

If various add-ons are sent all together in a short interval, subsequent transformation workflows cannot push to the repo if previous workflows have pushed unmerged changes.

### Strategy to fix the issue

Use concurrency in the transformation workflow with cancel-in-progress set to true, so that the last called workflow can be run.

### Tests

See workflows 23-25 of my fork:


- [23](https://github.com/nvdaes/addon-datastore/actions/runs/5759362383)
- [24](https://github.com/nvdaes/addon-datastore/actions/runs/5759368909)
- [25](https://github.com/nvdaes/addon-datastore/actions/runs/5759431050)