### PR TITLE
Create 2 tiered approval system

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -14,8 +14,46 @@ on:
         type: string
 
 jobs:
-  verifySubmitter:
+  getAddonFilename:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: [ 3.11 ]
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    outputs:
+      addonFileName: ${{ steps.getMetadata.outputs.result }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.headRef }}
+      - name: Create validation errors file
+        run: echo "" > validationErrors.md
+      - name: Determine files changed
+        uses: actions/github-script@v6
+        id: getMetadata
+        env:
+          pullRequestNumber: ${{ inputs.pullRequestNumber }}
+        with:
+          script: |
+            const getAddonFilename = require('./.github/workflows/checkFilesChanged.js')
+            const url = "GET /repos/" + process.env.GITHUB_REPOSITORY + "/pulls/" + process.env.pullRequestNumber + "/files" 
+            const result = await github.request(url)
+            return getAddonFilename(result.data)
+      - name: Post validation errors as comment
+        if: failure()
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ inputs.issueNumber }}
+          body-file: ./validationErrors.md
+  verifySubmitter:
+    # jq for windows has issues parsing multiline strings (e.g. CRLF),
+    # use linux instead.
+    runs-on: ubuntu-latest
+    needs: [getAddonFilename]
     strategy:
       matrix:
         python-version: [ 3.11 ]
@@ -26,13 +64,46 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Check if submitter is registered
+      - name: Check if submitter is trusted to submit for this add-on or any add-on ID
         id: checkReg
-        run: if ($(jq '. | .[\"${{ github.actor_id }}\"] | length' submitters.json) -eq 0) {throw "Submitter not registered"}
-      - name: Add submitter to JSON file
+        run: |
+          addonId=$(
+            echo ${{ needs.getAddonFilename.outputs.addonFileName }} \
+            | sed -r "s|addons/(.*)/.*\.json|\1|g"
+          )
+          jqCode="
+          . | .[\"${{ github.actor_id }}\"]
+          | select(
+            .trustedSubmitter
+            or (
+              .addons
+              | index(\"$addonId\")
+            )
+          )
+          "
+
+          jq -e "$jqCode" submitters.json
+          # -e only sets the exit status of jq to 0 if there is "truthy" output.
+          # If no valid result is produced, i.e. no submitter is found, jq exits with status 4.
+          # If there is a different error, a different non-zero exit code is used.
+          exit $? # Exit with the same exit code as jq
+      - name: Add add-on ID and submitter to JSON file
         if: failure()
         run: |
-          $(jq '. += {\"${{ github.actor_id }}\": \"${{ github.actor }}\"}' submitters.json) | echo > submitters.json
+          addonId=$(
+            echo ${{ needs.getAddonFilename.outputs.addonFileName }} \
+            | sed -r "s|addons/(.*)/.*\.json|\1|g"
+          )
+          jqCode="
+          .[\"${{ github.actor_id }}\"].addons += [\"$addonId\"]
+          | .[\"${{ github.actor_id }}\"].githubName = \"${{ github.actor }}\"
+          "
+
+          mv submitters.json submitters.old.json
+          jq -e "$jqCode" submitters.old.json > submitters.json
+          jqExitCode=$?
+          rm submitters.old.json
+          exit $jqExitCode
       - name: Create submitter approval PR
         if: failure()
         id: addSubmitterPR
@@ -54,8 +125,7 @@ jobs:
             Please wait until #${{ steps.addSubmitterPR.outputs.pull-request-number }} is merged.
   checkMetadata:
     runs-on: windows-latest
-    outputs:
-      addonFileName: ${{ steps.getMetadata.outputs.result }}
+    needs: [getAddonFilename]
     permissions:
       issues: write
       pull-requests: write
@@ -69,17 +139,6 @@ jobs:
         ref: ${{ inputs.headRef }}
     - name: Create validation errors file
       run: echo "" > validationErrors.md
-    - name: Determine files changed
-      uses: actions/github-script@v6
-      id: getMetadata
-      env:
-        pullRequestNumber: ${{ inputs.pullRequestNumber }}
-      with:
-        script: |
-          const getAddonFilename = require('./.github/workflows/checkFilesChanged.js')
-          const url = "GET /repos/" + process.env.GITHUB_REPOSITORY + "/pulls/" + process.env.pullRequestNumber + "/files" 
-          const result = await github.request(url)
-          return getAddonFilename(result.data)
     - name: Checkout validate repo
       uses: actions/checkout@v3
       with:
@@ -96,7 +155,7 @@ jobs:
         repository: nvaccess/addon-datastore-transform
         path: transform
     - name: Validate metadata
-      run: validation/runvalidate ${{ steps.getMetadata.outputs.result }} ./transform/nvdaAPIVersions.json --output ./validationErrors.md
+      run: validation/runvalidate ${{ needs.getAddonFilename.outputs.addonFileName }} ./transform/nvdaAPIVersions.json --output ./validationErrors.md
     - name: Post validation errors as comment
       if: failure()
       uses: peter-evans/create-or-update-comment@v2
@@ -115,7 +174,7 @@ jobs:
       with:
         issue-number: ${{ inputs.issueNumber }}
   mergeToMaster:
-    needs: [checkMetadata, verifySubmitter]
+    needs: [getAddonFilename, checkMetadata, verifySubmitter]
     permissions:
       contents: write
       pull-requests: write
@@ -129,7 +188,7 @@ jobs:
       with:
         source_ref: ${{ inputs.headRef }}
         target_branch: master
-        commit_message_template: '[Automated] Merged ${{ needs.checkMetadata.outputs.addonFileName }} (#${{ inputs.pullRequestNumber }}) into master'
+        commit_message_template: '[Automated] Merged ${{ needs.getAddonFilename.outputs.addonFileName }} (#${{ inputs.pullRequestNumber }}) into master'
   call-workflow:
     needs: mergeToMaster
     uses: ./.github/workflows/transformDataToViews.yml

--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ The checksum allows NVDA to ensure that add-on releases are immutable.
 
 ### Human review process / code audit
 - NV Access doesn't require a manual review of the add-on (code or user experience) itself before the add-on submission.
+- NV Access manually maintains a list of approved submitters with permission to submit an add-on to the store
 - You are welcome to review code / UX of add-ons and provide that feedback directly to add-on authors.
 - The SHA256 checksum of the `.nvda-addon` prevents undetected changes.
 - Add-ons should comply with the [NVDA code of conduct](https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md).
 Add-ons which are malicious or otherwise break the code of conduct can be removed by:
   - Opening a pull request to remove the submitted add-on metadata
-  - Sending an email to info@nvaccess.org
+  - Sending an email to <info@nvaccess.org>
 
 ### Non-exclusivity
 This system does not restrict add-on authors from developing, publishing, and distributing an add-on outside this store.

--- a/docs/submitters/submissionGuide.md
+++ b/docs/submitters/submissionGuide.md
@@ -19,6 +19,7 @@ If you do not maintain the submitted add-on's repository, it is expected that yo
 
 If you submit many add-ons you may be granted trusted submitter status, which allows you to publish/submit for all add-ons.
 It is expected that trusted submitters do not abuse this process.
+Granting and removing trusted submitter status of publishers will be decided and handled entirely by NV access.
 
 Submitters which abuse the submission process will have their submitter approval revoked.
 Please report any issues with submitted add-ons to <info@nvaccess.org>.

--- a/docs/submitters/submissionGuide.md
+++ b/docs/submitters/submissionGuide.md
@@ -1,7 +1,7 @@
 # Submission Guide
-If your add-on was hosted on [addonFiles](https://github.com/nvaccess/addonFiles) please read the [migrating to datastore guide](./migratingFromAddonFiles.md).
+Submitted add-ons should comply with the [NVDA code of conduct](https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md).
 
-Submitted add-ons should comply with the [NVDA code of conduct](https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md)
+If your add-on was hosted on [addonFiles](https://github.com/nvaccess/addonFiles) please read the [migrating to datastore guide](./migratingFromAddonFiles.md).
 
 ## Background
 Submitting an add-on version is done via a GitHub issue form.
@@ -13,15 +13,21 @@ Automated validation checks are run against the pull request.
 If there are validation errors, they will be commented on the pull request.
 Otherwise, the pull request will be merged, the issue will be closed and the add-on will become available in the Add-on Store.
 
-It is expected that submitters do not hijack add-on IDs by submitting an add-on which shares an add-on ID of an existing add-on.
-If you are an add-on author and your add-on ID has been hijacked, please open an issue or contact <info@nvaccess.org>.
-Submitters which abuse this process will have their submission approval revoked.
+## Approval process
+Publishers must be approved to submit add-ons, on a per add-on basis.
+If you do not maintain the submitted add-on's repository, it is expected that you have authorisation to publish the add-on from the authors.
+
+If you submit many add-ons you may be granted trusted submitter status, which allows you to publish/submit for all add-ons.
+It is expected that trusted submitters do not abuse this process.
+
+Submitters which abuse the submission process will have their submitter approval revoked.
+Please report any issues with submitted add-ons to <info@nvaccess.org>.
 
 ## Steps to submit an add-on
 1. Select ["Add-on registration" from the new issue options](https://github.com/nvaccess/addon-datastore/issues/new/choose).
 1. Fill out and submit the issue form.
 This will create an issue with a summary of your submission, and generate a pull request to submit your add-on to the store.
-1. If this is your first submission, manual approval will be required to be added to the approved submitters list.
+1. If this is your first submission of this add-on, manual approval will be required to be added to the approved submitters list for the add-on.
 1. Automated checks are ran on the pull request to validate the submission.
 Refer to [addon-datastore-validation](https://github.com/nvaccess/addon-datastore-validation) for more information on automated checks.
 1. If the checks fail, a comment should be added to the issue outlining the failure.

--- a/docs/submitters/submissionGuide.md
+++ b/docs/submitters/submissionGuide.md
@@ -19,7 +19,7 @@ If you do not maintain the submitted add-on's repository, it is expected that yo
 
 If you submit many add-ons you may be granted trusted submitter status, which allows you to publish/submit for all add-ons.
 It is expected that trusted submitters do not abuse this process.
-Granting and removing trusted submitter status of publishers will be decided and handled entirely by NV access.
+Granting and removing trusted submitter status of publishers will be decided and handled entirely by NV Access.
 
 Submitters which abuse the submission process will have their submitter approval revoked.
 Please report any issues with submitted add-ons to <info@nvaccess.org>.

--- a/submitters.json
+++ b/submitters.json
@@ -1,7 +1,27 @@
 {
-  "7090342": "seanbudd",
-  "15809252": "nvdaes",
-  "7867280": "josephsl",
-  "8139760": "XLTechie",
-  "75214948": "RPTools-org"
+  "15809252": {
+    "githubName": "nvdaes",
+    "trustedSubmitter": true
+  },
+  "7867280": {
+    "githubName": "josephsl",
+    "trustedSubmitter": true
+  },
+  "8139760": {
+    "githubName": "XLTechie",
+    "trustedSubmitter": true
+  },
+  "16865203": {
+    "githubName": "CyrilleB79",
+    "trustedSubmitter": true
+  },
+  "75214948": {
+    "githubName": "RPTools-org",
+    "addons": [
+      "controlTypeBeforeLabel",
+      "filezilla",
+      "landropPlus",
+      "thunderbirdPlus"
+    ]
+  }
 }


### PR DESCRIPTION
Closes https://github.com/nvaccess/addon-datastore/issues/1165

### Issue description
Currently a user must be approved to submit add-ons to the add-on store.
Once a submitter is approved, they can submit to any add-on ID.
This allows any approved submitter to effectively "hijack" an add-on, by replacing an existing add-on with their own add-on in the add-on store.
To prevent this, most submitters should be registered on a per add-on basis.

However, there are a few trusted publishers which submit many add-ons, often on behalf of authors.
Limiting the submission process on a per add-on basis for these submitters will be high maintenance.
As such, trusted high volume publishers will be able to publish for any add-on id.
Granting and removing trusted submitter status of publishers will be decided and handled entirely by NV Access.

### PR description
When submitting an add-on, check if the GitHub user ID and add-on ID matches the allow-list.
If the user is not registered, fail the PR early and add a comment notifying the author that the submission will be need to be manually approved.
Once the submitter has been authorized, subsequent submissions for the add-on should be merged automatically.
Once the submission PRs have been manually merged, the transformation to views must be manually run.
This can be done by relabelling the original issue.

### Testing
[GitHub action where a user was not registered](https://github.com/nvaccess/addon-datastore-staging/actions/runs/5851194172) resulting in https://github.com/nvaccess/addon-datastore-staging/pull/53/commits/0d43285e5464df75ece2e6e1e3ae44e924ceb9c8

Various local testing of the jq and different situations:
- author already registered, but not for the specified add-on
- author not registered at all
- author a trusted submitter

