### PR TITLE
Mark add-ons targeting 2024.1 as dev channel

### DIFF
--- a/addons/NVDARecorder/2023.9.18.json
+++ b/addons/NVDARecorder/2023.9.18.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/NVDARecorder",
 	"license": "GPL v2",

--- a/addons/addonsHelp/2023.9.21.json
+++ b/addons/addonsHelp/2023.9.21.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/addonsHelp",
 	"license": "GPL v2",

--- a/addons/agenda/2023.9.25.json
+++ b/addons/agenda/2023.9.25.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/agenda-for-NVDA",
 	"license": "GPL v2",

--- a/addons/applicationDictionary/2023.9.19.json
+++ b/addons/applicationDictionary/2023.9.19.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/applicationDictionary",
 	"license": "GPL v2",

--- a/addons/applicationDictionary/2023.9.24.json
+++ b/addons/applicationDictionary/2023.9.24.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/applicationDictionary-",
 	"license": "GPL v2",

--- a/addons/dictionaries/2023.10.1.json
+++ b/addons/dictionaries/2023.10.1.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/Dictionaries",
 	"license": "GPL v2",

--- a/addons/dropbox/2023.10.1.json
+++ b/addons/dropbox/2023.10.1.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/dropbox",
 	"license": "GPL v2",

--- a/addons/remapApplicationsKey/2023.9.26.json
+++ b/addons/remapApplicationsKey/2023.9.26.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/RemapKeyAplication-para-NVDA",
 	"license": "GPL v2",

--- a/addons/remapApplicationsKey/2023.9.30.json
+++ b/addons/remapApplicationsKey/2023.9.30.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/RemapKeyAplication-para-NVDA",
 	"license": "GPL v2",

--- a/addons/systrayList/2023.9.18.json
+++ b/addons/systrayList/2023.9.18.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/systrayList",
 	"license": "GPL v2",

--- a/addons/tesseractOCR/2023.9.26.json
+++ b/addons/tesseractOCR/2023.9.26.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/tesseractOCR",
 	"license": "GPL v2",

--- a/addons/virtualRevision/2023.9.19.json
+++ b/addons/virtualRevision/2023.9.19.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/virtualReview",
 	"license": "GPL v2",

--- a/addons/vocalizer_automotive_driver/2.1.5.json
+++ b/addons/vocalizer_automotive_driver/2.1.5.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/vocalizer_automotive_driver",
 	"license": "GPL v2",

--- a/addons/vocalizer_expressive_driver/3.1.9.json
+++ b/addons/vocalizer_expressive_driver/3.1.9.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/vocalizer_expressive_driver",
 	"license": "GPL v2",

--- a/addons/wordCount/2023.9.25.json
+++ b/addons/wordCount/2023.9.25.json
@@ -20,7 +20,7 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"channel": "stable",
+	"channel": "dev",
 	"publisher": "Rui Fontes",
 	"sourceURL": "https://github.com/ruifontes/wordCount",
 	"license": "GPL v2",


### PR DESCRIPTION
Relates to https://github.com/nvaccess/addon-datastore-validation/pull/33 https://github.com/nvaccess/nvda/pull/15607

As 2024.1 is in alpa, add-ons using the 2024.1 API should not be marked as stable using the stable channel. This PR marks them as dev.