### PR TITLE
Fix push at the same time for createReviewComment job

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -321,6 +321,7 @@ jobs:
         git config user.email github-actions@github.com
         git add .
         git commit -m "update discussion URL"
+        git branch -u origin/master
         git pull
         git push
 


### PR DESCRIPTION
### Summary of the issue

When various workflows push at the same time, in the createReviewComment job, failures maybe produced since the local branch is not updated, even after preforming `git pull`.
This has been reported by @seanbudd in PR #1951.

### Development strategy

Before pulling, set origin/master as the upstream  branch, since we used ${{github.ref }} in the checkout action.

### Testing strategy

Submit two add-ons consecutively to nvdaes/addon-datastore, anc confirmed that createReviewComment jobs have been successful.



- https://github.com/nvdaes/addon-datastore/actions/runs/6766456966

- https://github.com/nvdaes/addon-datastore/actions/runs/6766450298