### PR TITLE
Fix channel for readFeeds

### DIFF
--- a/addons/readFeeds/26.0.2.json
+++ b/addons/readFeeds/26.0.2.json
@@ -20,7 +20,7 @@
     "minor": 1,
     "patch": 0
   },
-  "channel": "stable",
+  "channel": "dev",
   "publisher": "nvdaes",
   "sourceURL": "https://github.com/nvdaes",
   "license": "GPL v2",


### PR DESCRIPTION
Apologies, my intention was to send this to my fork of this repo, but I typed nvaccess instead of nvdaes. The purpose was to fix a regression introduced by me in the review feature, hopely fixed in a previous pr.
