### PR TITLE
Parse special characters from add-on ID when creating approval branch

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -60,8 +60,7 @@ jobs:
           result-encoding: string
           script: |
             const addonId = "${{ steps.getAddonId.outputs.result }}"
-            const addonIdParsed = addonId.replace(/[^a-zA-Z0-9]/g, "")
-            return addonIdParsed
+            return addonId.replace(/[^a-zA-Z0-9]/g, "")
   verifySubmitter:
     # jq for windows has issues parsing multiline strings (e.g. CRLF),
     # use linux instead.

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       addonFileName: ${{ steps.getAddonFileName.outputs.result }}
       addonId: ${{ steps.getAddonId.outputs.result }}
+      addonIdParsed: ${{ steps.getAddonIdParsed.outputs.result }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -52,6 +53,15 @@ jobs:
             const addonFileName = ${{ steps.getAddonFileName.outputs.result }}
             const addonIdRegex = RegExp("addons/(.*)/.*\.json")
             return addonIdRegex.exec(addonFileName)[1]
+      - name: Parse spaces and special characters from addonID for branch names
+        uses: actions/github-script@v6
+        id: getAddonIdParsed
+        with:
+          result-encoding: string
+          script: |
+            const addonId = "${{ steps.getAddonId.outputs.result }}"
+            const addonIdParsed = addonIdRegex.exec(addonFileName)[1].replace(/[^a-zA-Z0-9]/g, "")
+            return addonIdParsed
   verifySubmitter:
     # jq for windows has issues parsing multiline strings (e.g. CRLF),
     # use linux instead.
@@ -107,7 +117,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           title: Add ${{ inputs.issueAuthorName }} as an approved submitter for ${{ needs.getAddonId.outputs.addonId }}
-          branch: addSubmitter${{ inputs.issueAuthorName }}${{ needs.getAddonId.outputs.addonId }}
+          branch: addSubmitter${{ inputs.issueAuthorName }}${{ needs.getAddonId.outputs.addonIdParsed }}
           commit-message: Add ${{ inputs.issueAuthorName }} as an approved submitter for ${{ needs.getAddonId.outputs.addonId }}
           body: "Created from #${{ inputs.issueNumber }}"
           author: github-actions <github-actions@github.com>

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -54,7 +54,7 @@ jobs:
             const addonIdRegex = RegExp("addons/(.*)/.*\.json")
             return addonIdRegex.exec(addonFileName)[1]
       - name: Parse spaces and special characters from addonID for branch names
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: getAddonIdParsed
         with:
           result-encoding: string

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -60,7 +60,7 @@ jobs:
           result-encoding: string
           script: |
             const addonId = "${{ steps.getAddonId.outputs.result }}"
-            const addonIdParsed = addonIdRegex.exec(addonFileName)[1].replace(/[^a-zA-Z0-9]/g, "")
+            const addonIdParsed = addonId.replace(/[^a-zA-Z0-9]/g, "")
             return addonIdParsed
   verifySubmitter:
     # jq for windows has issues parsing multiline strings (e.g. CRLF),


### PR DESCRIPTION
A recent regression meant that add-on IDs containing spaces caused the verify submitter PR to fail when an add-on is submitted for the first time.

This can be fixed by removing special characters when creating the temp branch for the PR to add the author as an approved submitter.

Tested with this add-on:
https://github.com/nvaccess/addon-datastore-staging/issues/54

Example failure on production:
https://github.com/nvaccess/addon-datastore/issues/2037