### PR TITLE
add add-on download errors to validation errors message

### DIFF
--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -43,7 +43,10 @@ jobs:
         # https://blog.gitguardian.com/github-actions-security-cheat-sheet/
         url: ${{ steps.get-data.outputs.downloadUrl }}
       # wrap all user input in quotations to prevent RCE e.g. www.example.com/&rm -rf
-      run: curl --location --output addon.nvda-addon "$env:url" 2> validationErrors.md
+      run: curl --location --output addon.nvda-addon "$env:url" 2>> validationErrors.md
+    - name: Add extra message if curl fails to validation errors
+      if: failure()
+      run: echo "Error with downloading add-on from download URL" 2>> validationErrors.md
     - name: Create JSON submission from issue
       env:
         # transfer user input to env variables to escape any code

--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -43,7 +43,7 @@ jobs:
         # https://blog.gitguardian.com/github-actions-security-cheat-sheet/
         url: ${{ steps.get-data.outputs.downloadUrl }}
       # wrap all user input in quotations to prevent RCE e.g. www.example.com/&rm -rf
-      run: curl --location --output addon.nvda-addon "$env:url"
+      run: curl --location --output addon.nvda-addon "$env:url" 2> validationErrors.md
     - name: Create JSON submission from issue
       env:
         # transfer user input to env variables to escape any code

--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -46,7 +46,7 @@ jobs:
       run: curl --location --output addon.nvda-addon "$env:url" 2>> validationErrors.md
     - name: Add extra message if curl fails to validation errors
       if: failure()
-      run: echo "Error with downloading add-on from download URL" 2>> validationErrors.md
+      run: echo "Error with downloading add-on from download URL" >> validationErrors.md
     - name: Create JSON submission from issue
       env:
         # transfer user input to env variables to escape any code


### PR DESCRIPTION
Invalid urls throw errors in curl when attempting to download the add-on file.

Add-on submitters should be notified of curl errors when trying to submit the add-on

Tested with this add-on:
https://github.com/nvaccess/addon-datastore-staging/issues/56

Example failure on production:
https://github.com/nvaccess/addon-datastore/issues/2081