### PR TITLE
Fix pr 2114: add discussionUrl from discussions.json

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -313,11 +313,14 @@ jobs:
         addonFilename=$(
           echo ${{ needs.getAddonId.outputs.addonFileName }}
         )
+        addonId=$(
+          echo ${{ needs.getAddonId.outputs.addonId }}
+        )
         reviewUrl=$(
-          echo ${{ steps.createDiscussion.outputs.discussion-url }}
+          jq ".\"$addonId\".discussionUrl" discussions.json
         )
         jqCode="
-        .[\"reviewUrl\"] = \"$reviewUrl\"
+        .[\"reviewUrl\"] = $reviewUrl
         "
   
         mv $addonFilename $addonFilename.old.json


### PR DESCRIPTION
### Link to issue number
Fixup of pr #2114

### Summary of the issue

When dropping the comments system, which added a comment for each add-on version to be reviewed, we used the discussion-url value from the create-discussion action. This addressed cases where the add-on discussion didn't exist, such as when releasing a new add-on. But this wouldn't work for add-ons previously published, since in those cases a discussion doesn't need to be created.

### Development strategy

Firstly, the discussion url, if it doesn't exist, is added to discussions.json file (if it exist, it's already placed on that file).
Now, we check the discussionUrlfrom discussions.json to add it to add-on metadata in all cases.

This has been tested with readFeeds add-on, whose discussion was previously added to discussions.json.


https://github.com/nvdaes/addon-datastore/actions/runs/7089904899/job/19295833182

