### PR TITLE
Create pull request and analize code before merging

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -215,8 +215,11 @@ jobs:
       uses: peter-evans/close-issue@v3
       with:
         issue-number: ${{ inputs.issueNumber }}
+  codeQL-analysis:
+    needs: createPullRequest
+    uses: ./.github/workflows/codeql-analysis.yml
   mergeToMaster:
-    needs: [getAddonId, createPullRequest]
+    needs: [getAddonId, createPullRequest, codeQL-analysis]
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -76,16 +76,3 @@ jobs:
             Security analysis has failed for this add-on.
             [See GitHub workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
             Please, contact NV Access for more details.
-      - name: Close issue
-        if: failure()
-        uses: peter-evans/close-issue@v3
-        with:
-          issue-number: ${{ github.event.issue.number }}
-  call-workflow-passing-data:
-    needs: analyze
-    uses: ./.github/workflows/checkAndSubmitAddonMetadata.yml
-    with:
-      issueNumber: "${{ github.event.issue.number }}"
-      issueAuthorId: ${{ github.event.issue.user.id }}
-      issueAuthorName: ${{ github.event.issue.user.login }}
-      issueTitle: ${{ github.event.issue.title }}

--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -90,6 +90,14 @@ jobs:
       with:
         name: addon
         path: addon.nvda-addon
+  call-workflow-passing-data:
+    needs: check-addon
+    uses: ./.github/workflows/checkAndSubmitAddonMetadata.yml
+    with:
+      issueNumber: "${{ github.event.issue.number }}"
+      issueAuthorId: ${{ github.event.issue.user.id }}
+      issueAuthorName: ${{ github.event.issue.user.login }}
+      issueTitle: ${{ github.event.issue.title }}
   codeQL-analysis:
     needs: check-addon
     uses: ./.github/workflows/codeql-analysis.yml


### PR DESCRIPTION
### Sumary of the issue

If codeQl analysis fails, a pull request is not created, and NV Access cannot merge it.

### Development strategy

Moved codeso that security analysis is done before merging the created pull request, and remove the step to close the submission issue.

### Tests

https://github.com/nvdaes/addon-datastore/actions/runs/8732062221
