### PR TITLE
Fix branch naming to be consistent

### DIFF
--- a/.github/workflows/getData.js
+++ b/.github/workflows/getData.js
@@ -7,7 +7,7 @@ module.exports = ({context, core}) => {
 	const issueNumber = context.payload.issue.number
 	core.setOutput('issueNumber', issueNumber)
 	// Knowing the submitter may be helpful
-	// const issueSubmitter = context.payload.sender.login
+	// const issueSubmitter = context.payload.issue.user.login
 	//
 	// Field headers, Md == Markdown
 	const header3Prefix = "###"

--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -81,10 +81,10 @@ jobs:
         cd datastore
         git config user.name github-actions
         git config user.email github-actions@github.com
-        git checkout -b ${{ github.event.sender.login }}${{ steps.get-data.outputs.issueNumber }}
+        git checkout -b ${{ github.event.issue.user.login }}${{ steps.get-data.outputs.issueNumber }}
         git add .
         git commit -m "Submit add-on"
-        git push origin ${{ github.event.sender.login }}${{ steps.get-data.outputs.issueNumber }}
+        git push origin ${{ github.event.issue.user.login }}${{ steps.get-data.outputs.issueNumber }}
     - name: Upload add-on
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
In parts of the code we use `${{ github.event.sender.login }}` as the reference to the author when creating branches based on submissions. Instead we should use ` ${{ github.event.issue.user.login }}` consistently so that if NV Access re-triggers an issue, the values are the same 