### PR TITLE
No longer scan JS with CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ 3.11 ]
-        language: ['javascript', 'python']
+        language: ['python']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
     steps:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The add-on store includes the following security measures:
 
 - Add-on file integrity can be enforced via a SHA256 checksum.
   - The checksum allows NVDA to ensure that add-on releases are immutable.
-- [Code scanning with CodeQL](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) can detect vulnerabilities in Python and JavaScript code included in submitted add-ons.
+- [Code scanning with CodeQL](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) can detect vulnerabilities in Python code included in submitted add-ons.
   - NV Access can manage [code scanning alerts](https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/about-code-scanning-alerts), available from the Code scanning link from the [Security page](https://github.com/nvaccess/addon-datastore/security).
 - [Virus Total](https://www.virustotal.com/) is used to scan submitted add-ons.
 If malicious content is detected, the add-on will not be automatically included in the store.


### PR DESCRIPTION
Fixes #4196

We perform 2 scans with CodeQL - one that blocks auto-merges if a critical error is found. The other just warns for other errors found. We check python and JS code in both.
An error is thrown when scanning JS code for add-ons with no JS code.
This PR makes it so we no longer block auto-merges on JS failures.
We still report some scan warnings for JS, as the warning check does not fail the build.