### PR TITLE
Fix up GestorDePomodoros and VLC

### DIFF
--- a/addons/VLC/2.16.0.json
+++ b/addons/VLC/2.16.0.json
@@ -11,8 +11,8 @@
 		"patch": 0
 	},
 	"minNVDAVersion": {
-		"major": 2018,
-		"minor": 1,
+		"major": 0,
+		"minor": 0,
 		"patch": 0
 	},
 	"lastTestedVersion": {

--- a/addons/gestorDePomodoros/1.3.0.json
+++ b/addons/gestorDePomodoros/1.3.0.json
@@ -1,7 +1,7 @@
 {
-  "addonId": "gestorDePomodoros",
+  "addonId": "GestorDePomodoros",
   "displayName": "Gestor de Pomodoros",
-  "URL": "https://github.com/jpavonabian/Gestor-de-Pomodoros/releases/download/v1.3/gestorDePomodoros-1.3.nvda-addon",
+  "URL": "https://github.com/jpavonabian/Gestor-de-Pomodoros/releases/download/v1.3/GestorDePomodoros-1.3.nvda-addon",
   "description": "Complemento que permite gestionar ciclos Pomodoros.\n\u00datil para estudiantes o trabajadores que necesitan ayuda para dispersarse menos o prestar m\u00e1s atenci\u00f3n a sus tareas.",
   "sha256": "f21c852fe2ca35df15f15b5cb1c94fd782fd9c7ee1522eaacd040baab8e5c437",
   "addonVersionName": "1.3",

--- a/addons/gestorDePomodoros/1.4.0.json
+++ b/addons/gestorDePomodoros/1.4.0.json
@@ -1,7 +1,7 @@
 {
-  "addonId": "gestorDePomodoros",
+  "addonId": "GestorDePomodoros",
   "displayName": "Gestor de Pomodoros",
-  "URL": "https://github.com/jpavonabian/Gestor-de-Pomodoros/releases/download/v1.4/gestorDePomodoros-1.4.nvda-addon",
+  "URL": "https://github.com/jpavonabian/Gestor-de-Pomodoros/releases/download/v1.4/GestorDePomodoros-1.4.nvda-addon",
   "description": "Complemento que permite gestionar ciclos Pomodoros.\n\u00datil para estudiantes o trabajadores que necesitan ayuda para dispersarse menos o prestar m\u00e1s atenci\u00f3n a sus tareas.",
   "sha256": "e21c4c81f33d5c84e63a1b866e087d895eab9631816f65b95dd8d7389d051b0a",
   "addonVersionName": "1.4",

--- a/addons/gestorDePomodoros/1.5.0.json
+++ b/addons/gestorDePomodoros/1.5.0.json
@@ -1,7 +1,7 @@
 {
-  "addonId": "gestorDePomodoros",
+  "addonId": "GestorDePomodoros",
   "displayName": "Gestor de Pomodoros",
-  "URL": "https://github.com/jpavonabian/Gestor-de-Pomodoros/releases/download/v1.5/gestorDePomodoros-1.5.nvda-addon",
+  "URL": "https://github.com/jpavonabian/Gestor-de-Pomodoros/releases/download/v1.5/GestorDePomodoros-1.5.nvda-addon",
   "description": "Complemento que permite gestionar ciclos Pomodoros.\n\u00datil para estudiantes o trabajadores que necesitan ayuda para dispersarse menos o prestar m\u00e1s atenci\u00f3n a sus tareas.",
   "sha256": "a8333d0bf073e13e3cfde4f886635c5d6a5085e363f2702c8df92c0cf265a52d",
   "addonVersionName": "1.5",

--- a/discussions.json
+++ b/discussions.json
@@ -527,10 +527,6 @@
     "discussionId": "D_kwDODeB9Us4AYqtA",
     "discussionUrl": "https://github.com/nvaccess/addon-datastore/discussions/3111"
   },
-  "gestorDePomodoros": {
-    "discussionId": "D_kwDODeB9Us4AYrbc",
-    "discussionUrl": "https://github.com/nvaccess/addon-datastore/discussions/3135"
-  },
   "instantTranslate": {
     "discussionId": "D_kwDODeB9Us4AYrnu",
     "discussionUrl": "https://github.com/nvaccess/addon-datastore/discussions/3140"

--- a/submitters.json
+++ b/submitters.json
@@ -421,7 +421,6 @@
   },
   "12977038": {
     "addons": [
-      "gestorDePomodoros",
       "GestorDePomodoros"
     ],
     "githubName": "jpavonabian"


### PR DESCRIPTION
`GestorDePomodoros` has a duplicate alias with different casing `gestorDePomodoros`.

This should be resolved by merging the content. This should be handled easily within NVDA.

A version of the VLC add-on has an invalid API Version, this should be fixed.