### PR TITLE
Update validation check to delete add-ons which cannot be downloaded

### DIFF
--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -1,0 +1,52 @@
+const glob = require('glob');
+const crypto = require('crypto');
+const hash = crypto.createHash('sha256');
+
+module.exports = ({core}, globPattern) => {
+  const fs = require('fs');
+  const { exec } = require('child_process');
+  const files = glob.globSync(globPattern);
+  files.forEach(file => {
+    const addonMetadataContents = fs.readFileSync(file);
+    const addonMetadata = JSON.parse(addonMetadataContents);
+    const addonId = addonMetadata.addonId;
+    const sha256 = addonMetadata.sha256;
+    exec(`curl --location --output ${addonId}.nvda-addon "${addonMetadata.URL}"`, (err, stdout, stderr) => {
+      if (stderr !== '' || err !== null) {
+        console.log(`err: ${err}`);
+        console.log(`stdout: ${stdout}`);
+        console.log(`stderr: ${stderr}`);
+        // delete file if download failed
+        exec(`rm ${file}`, (err, stdout, stderr) => {
+          if (stderr !== '' || err !== null) {
+            console.log(`err: ${err}`);
+            console.log(`stdout: ${stdout}`);
+            console.log(`stderr: ${stderr}`);
+            core.setFailed('Failed to delete add-on file');
+            return;
+          }
+        })
+      }
+      // if hash mismatches, delete the file
+      hash.setEncoding('hex');
+      const fileStream = fs.createReadStream(`${addonId}.nvda-addon`);
+      fileStream.on('data', chunk => {
+        hash.update(chunk);
+      });
+      fileStream.on('end', () => {
+        const fileHash = hash.digest('hex');
+        if (fileHash !== sha256) {
+          exec(`rm ${file}`, (err, stdout, stderr) => {
+            if (stderr !== '' || err !== null) {
+              console.log(`err: ${err}`);
+              console.log(`stdout: ${stdout}`);
+              console.log(`stderr: ${stderr}`);
+              core.setFailed('Failed to delete add-on file');
+              return;
+            }
+          })
+        }
+      })
+    });
+  });
+};

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -8,7 +8,7 @@ const PROJECT_URL = "https://github.com/nvaccess/addon-datastore/blob/master/";
 function removeMetadataFile({core}, metadataFile, reason) {
   console.log(`Deleting file "${metadataFile}" because ${reason}`);
   // normalise the Windows-style path to be usable for the URL in the PR body
-  const metadataFileNormalised = metadataFile.replace(/\\/g, '/');
+  const metadataFileNormalised = metadataFile.replaceAll('\\', '/');
   core._PRBodyString += `| [${metadataFileNormalised.replace("addons/", "")}](${PROJECT_URL}${metadataFileNormalised}) | ${reason} |\n`;
   core.setOutput("PRBodyString", core._PRBodyString);
   exec(`rm "${metadataFile}"`, (err, stdout, stderr) => {
@@ -61,7 +61,7 @@ function checkMetadataDownloadResult({core}, metadataFile, downloadFileName, sha
     console.log(`stdout: ${stdout}`);
     console.log(`stderr: ${stderr}`);
     // strip newlines and carriage returns from stderr to avoid breaking the markdown table
-    const strippedStderr = stderr.replace("\n", "  ").replace("\r", "");
+    const strippedStderr = stderr.replaceAll("\n", "  ").replaceAll("\r", "");
     removeMetadataFile({core}, metadataFile, `Download failed: ${strippedStderr}`); 
     return;
   }

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -26,6 +26,7 @@ module.exports = ({core}, globPattern) => {
             return;
           }
         })
+        return;
       }
       // if hash mismatches, delete the file
       hash.setEncoding('hex');
@@ -39,12 +40,12 @@ module.exports = ({core}, globPattern) => {
           exec(`rm ${file}`, (err, stdout, stderr) => {
             if (stderr !== '' || err !== null) {
               console.log(`err: ${err}`);
-              console.log(`stdout: ${stdout}`);
               console.log(`stderr: ${stderr}`);
               core.setFailed('Failed to delete add-on file');
               return;
             }
           })
+          return;
         }
       })
     });

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -10,7 +10,7 @@ function removeMetadataFile({core}, metadataFile, reason) {
   exec(`rm "${metadataFile}"`, (err, stdout, stderr) => {
     // stdout is garbage here, so we don't use it
     metadataFileNormalised = metadataFile.replace(/\\/g, '/');
-    core._PRBodyString += `| [${metadataFileNormalised}](${PROJECT_URL}${metadataFileNormalised}) | ${reason} |\n`;
+    core._PRBodyString += `| [${metadataFileNormalised.replace("addons/", "")}](${PROJECT_URL}${metadataFileNormalised}) | ${reason} |\n`;
     core.setOutput("PRBodyString", core._PRBodyString);
     if (stderr !== '' || err !== null) {
       console.log(`err: ${err}`);
@@ -48,7 +48,7 @@ function checkDownloadedAddonHash({core}, downloadFileName, metadataFile, sha256
     // delete downloaded file
     removeDownloadedAddonFile(downloadFileName, metadataFile);
     if (fileHash.toLowerCase() !== sha256.toLowerCase()) {
-      removeMetadataFile({core}, metadataFile, `Hash mismatch ${fileHash} !== ${sha256}"`);
+      removeMetadataFile({core}, metadataFile, `Hash mismatch ${fileHash} (actual) != ${sha256} (expected)`);
       return;
     }
   });

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -8,6 +8,7 @@ const PROJECT_URL = "https://github.com/nvaccess/addon-datastore/blob/master/";
 function removeMetadataFile({core}, metadataFile, reason) {
   console.log(`Deleting file "${metadataFile}" because ${reason}`);
   exec(`rm "${metadataFile}"`, (err, stdout, stderr) => {
+    // stdout is garbage here, so we don't use it
     metadataFileNormalised = metadataFile.replace(/\\/g, '/');
     core._PRBodyString += `| [${metadataFileNormalised}](${PROJECT_URL}${metadataFileNormalised}) | ${reason} |\n`;
     if (stderr !== '' || err !== null) {

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -9,9 +9,9 @@ module.exports = ({core}, globPattern) => {
   files.forEach(file => {
     const addonMetadataContents = fs.readFileSync(file);
     const addonMetadata = JSON.parse(addonMetadataContents);
-    const addonId = addonMetadata.addonId;
     const sha256 = addonMetadata.sha256;
     const downloadFileName = `${uuidv4()}.nvda-addon`;
+    // if download fails, delete the addon data file
     exec(
       `curl --fail --silent --show-error --location --output "${downloadFileName}" "${addonMetadata.URL}"`,
       // increase maxBuffer size to 10GB
@@ -33,9 +33,10 @@ module.exports = ({core}, globPattern) => {
         })
         return;
       }
+
+      // if hash mismatches, delete the addon data file
       const hash = crypto.createHash('sha256');
       hash.write("")
-      // if hash mismatches, delete the file
       hash.setEncoding('hex');
       const fileStream = fs.createReadStream(downloadFileName);
       fileStream.on('data', chunk => {

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -1,6 +1,5 @@
 const glob = require('glob');
 const crypto = require('crypto');
-const hash = crypto.createHash('sha256');
 
 module.exports = ({core}, globPattern) => {
   const fs = require('fs');
@@ -11,6 +10,7 @@ module.exports = ({core}, globPattern) => {
     const addonMetadata = JSON.parse(addonMetadataContents);
     const addonId = addonMetadata.addonId;
     const sha256 = addonMetadata.sha256;
+    const hash = crypto.createHash('sha256');
     exec(`curl --fail --silent --show-error --location --output ${addonId}.nvda-addon "${addonMetadata.URL}"`, (err, stdout, stderr) => {
       if (stderr !== '' || err !== null) {
         console.log(`err: ${err}`);

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -1,6 +1,6 @@
 const glob = require('glob');
 const crypto = require('crypto');
-const uuidv4 = require('uuid/v4');
+const { v4: uuidv4 } = require('uuid');
 
 module.exports = ({core}, globPattern) => {
   const fs = require('fs');

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -1,73 +1,85 @@
 const glob = require('glob');
 const crypto = require('crypto');
 const { v4: uuidv4 } = require('uuid');
+const fs = require('fs');
+const { exec } = require('child_process');
+
+function removeMetadataFile({core}, metadataFile) {
+  exec(`rm "${metadataFile}"`, (err, stdout, stderr) => {
+    if (stderr !== '' || err !== null) {
+      console.log(`err: ${err}`);
+      console.log(`stderr: ${stderr}`);
+      core.setFailed(`Failed to delete add-on file: ${metadataFile}`);
+      return;
+    }
+  })
+}
+
+function removeDownloadedAddonFile(downloadFileName) {
+  exec(`rm "${downloadFileName}"`, (err, stdout, stderr) => {
+    if (stderr !== '' || err !== null) {
+      console.log(`err: ${err}`);
+      console.log(`stdout: ${stdout}`);
+      console.log(`stderr: ${stderr}`);
+      console.error(`Failed to delete downloaded add-on file for ${metadataFile}`);
+      return;
+    }
+  })
+}
+
+function checkDownloadedAddonHash({core}, downloadFileName, sha256) {
+  // if hash mismatches, delete the addon data file
+  const hash = crypto.createHash('sha256');
+  hash.write("")
+  hash.setEncoding('hex');
+  const fileStream = fs.createReadStream(downloadFileName);
+  fileStream.on('data', chunk => {
+    hash.update(chunk);
+  });
+  fileStream.on('end', () => {
+    const fileHash = hash.digest('hex');
+    hash.end();
+    // delete downloaded file
+    removeDownloadedAddonFile(downloadFileName);
+    if (fileHash.toLowerCase() !== sha256.toLowerCase()) {
+      console.log(`Hash mismatch: ${fileHash} !== ${sha256}, deleting file "${metadataFile}"`);
+      removeMetadataFile({core}, metadataFile);
+      return;
+    }
+  });
+}
+
+function checkMetadataDownloadResult({core}, metadataFile, sha256, err, stdout, stderr) {
+  if (stderr !== '' || err !== null) {
+    console.log(`err: ${err}`);
+    console.log(`stdout: ${stdout}`);
+    console.log(`stderr: ${stderr}`);
+    // delete file if download failed
+    removeMetadataFile({core}, metadataFile);
+    return;
+  }
+
+  checkDownloadedAddonHash({core}, downloadFileName, sha256);
+}
+
+function checkMetadataFile({core}, metadataFile) {
+  const addonMetadataContents = fs.readFileSync(metadataFile);
+  const addonMetadata = JSON.parse(addonMetadataContents);
+  const sha256 = addonMetadata.sha256;
+  const downloadFileName = `${uuidv4()}.nvda-addon`;
+  // if download fails, delete the addon data file
+  exec(
+    `curl --fail --silent --show-error --location --output "${downloadFileName}" "${addonMetadata.URL}"`,
+    // increase maxBuffer size to 10GB
+    { maxBuffer: 1024 * 1024 * 1024 * 10 },
+    (err, stdout, stderr) => {
+      checkMetadataDownloadResult({core}, metadataFile, sha256, err, stdout, stderr);
+  });
+}
 
 module.exports = ({core}, globPattern) => {
-  const fs = require('fs');
-  const { exec } = require('child_process');
-  const files = glob.globSync(globPattern);
-  files.forEach(file => {
-    const addonMetadataContents = fs.readFileSync(file);
-    const addonMetadata = JSON.parse(addonMetadataContents);
-    const sha256 = addonMetadata.sha256;
-    const downloadFileName = `${uuidv4()}.nvda-addon`;
-    // if download fails, delete the addon data file
-    exec(
-      `curl --fail --silent --show-error --location --output "${downloadFileName}" "${addonMetadata.URL}"`,
-      // increase maxBuffer size to 10GB
-      { maxBuffer: 1024 * 1024 * 1024 * 10 },
-      (err, stdout, stderr) => {
-      if (stderr !== '' || err !== null) {
-        console.log(`err: ${err}`);
-        console.log(`stdout: ${stdout}`);
-        console.log(`stderr: ${stderr}`);
-        // delete file if download failed
-        exec(`rm "${file}"`, (err, stdout, stderr) => {
-          if (stderr !== '' || err !== null) {
-            console.log(`err: ${err}`);
-            console.log(`stdout: ${stdout}`);
-            console.log(`stderr: ${stderr}`);
-            core.setFailed(`Failed to delete add-on file: ${file}`);
-            return;
-          }
-        })
-        return;
-      }
-
-      // if hash mismatches, delete the addon data file
-      const hash = crypto.createHash('sha256');
-      hash.write("")
-      hash.setEncoding('hex');
-      const fileStream = fs.createReadStream(downloadFileName);
-      fileStream.on('data', chunk => {
-        hash.update(chunk);
-      });
-      fileStream.on('end', () => {
-        const fileHash = hash.digest('hex');
-        hash.end();
-        // delete downloaded file
-        exec(`rm "${downloadFileName}"`, (err, stdout, stderr) => {
-          if (stderr !== '' || err !== null) {
-            console.log(`err: ${err}`);
-            console.log(`stdout: ${stdout}`);
-            console.log(`stderr: ${stderr}`);
-            console.error(`Failed to delete downloaded add-on file for ${file}`);
-            return;
-          }
-        })
-        if (fileHash.toLowerCase() !== sha256.toLowerCase()) {
-          console.log(`Hash mismatch: ${fileHash} !== ${sha256}, deleting file "${file}"`);
-          exec(`rm "${file}"`, (err, stdout, stderr) => {
-            if (stderr !== '' || err !== null) {
-              console.log(`err: ${err}`);
-              console.log(`stderr: ${stderr}`);
-              core.setFailed(`Failed to delete add-on file: ${file}`);
-              return;
-            }
-          })
-          return;
-        }
-      })
-    });
+  const metadataFiles = glob.globSync(globPattern);
+  metadataFiles.forEach(metadataFile => {
+    checkMetadataFile({core}, metadataFile);
   });
 };

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -27,7 +27,7 @@ function removeDownloadedAddonFile(downloadFileName, metadataFile) {
   })
 }
 
-function checkDownloadedAddonHash({core}, downloadFileName, sha256) {
+function checkDownloadedAddonHash({core}, downloadFileName, metadataFile, sha256) {
   // if hash mismatches, delete the addon data file
   const hash = crypto.createHash('sha256');
   hash.write("")
@@ -59,7 +59,7 @@ function checkMetadataDownloadResult({core}, metadataFile, downloadFileName, sha
     return;
   }
 
-  checkDownloadedAddonHash({core}, downloadFileName, sha256);
+  checkDownloadedAddonHash({core}, downloadFileName, metadataFile, sha256);
 }
 
 function checkMetadataFile({core}, metadataFile) {

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -40,7 +40,8 @@ module.exports = ({core}, globPattern) => {
       });
       fileStream.on('end', () => {
         const fileHash = hash.digest('hex');
-        if (fileHash !== sha256) {
+        if (fileHash.toLowerCase() !== sha256.toLowerCase()) {
+          console.log(`Hash mismatch: ${fileHash} !== ${sha256}, deleting file`);
           exec(`rm "${file}"`, (err, stdout, stderr) => {
             if (stderr !== '' || err !== null) {
               console.log(`err: ${err}`);

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -11,7 +11,11 @@ module.exports = ({core}, globPattern) => {
     const addonId = addonMetadata.addonId;
     const sha256 = addonMetadata.sha256;
     const hash = crypto.createHash('sha256');
-    exec(`curl --fail --silent --show-error --location --output ${addonId}.nvda-addon "${addonMetadata.URL}"`, (err, stdout, stderr) => {
+    exec(
+      `curl --fail --silent --show-error --location --output ${addonId}.nvda-addon "${addonMetadata.URL}"`,
+      // increase maxBuffer size to 10GB
+      { maxBuffer: 1024 * 1024 * 1024 * 10 },
+      (err, stdout, stderr) => {
       if (stderr !== '' || err !== null) {
         console.log(`err: ${err}`);
         console.log(`stdout: ${stdout}`);

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -11,7 +11,7 @@ module.exports = ({core}, globPattern) => {
     const addonMetadata = JSON.parse(addonMetadataContents);
     const addonId = addonMetadata.addonId;
     const sha256 = addonMetadata.sha256;
-    exec(`curl --location --output ${addonId}.nvda-addon "${addonMetadata.URL}"`, (err, stdout, stderr) => {
+    exec(`curl --fail --silent --show-error --location --output ${addonId}.nvda-addon "${addonMetadata.URL}"`, (err, stdout, stderr) => {
       if (stderr !== '' || err !== null) {
         console.log(`err: ${err}`);
         console.log(`stdout: ${stdout}`);

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -60,7 +60,8 @@ function checkMetadataDownloadResult({core}, metadataFile, downloadFileName, sha
     console.log(`stdout: ${stdout}`);
     console.log(`stderr: ${stderr}`);
     // delete file if download failed
-    removeMetadataFile({core}, metadataFile, `Download failed: ${stderr}`); 
+    strippedStderr = stderr.replace("\n", "  ");
+    removeMetadataFile({core}, metadataFile, `Download failed: ${strippedStderr}`); 
     return;
   }
 

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -15,7 +15,7 @@ function removeMetadataFile({core}, metadataFile) {
   })
 }
 
-function removeDownloadedAddonFile(downloadFileName) {
+function removeDownloadedAddonFile(downloadFileName, metadataFile) {
   exec(`rm "${downloadFileName}"`, (err, stdout, stderr) => {
     if (stderr !== '' || err !== null) {
       console.log(`err: ${err}`);
@@ -40,7 +40,7 @@ function checkDownloadedAddonHash({core}, downloadFileName, sha256) {
     const fileHash = hash.digest('hex');
     hash.end();
     // delete downloaded file
-    removeDownloadedAddonFile(downloadFileName);
+    removeDownloadedAddonFile(downloadFileName, metadataFile);
     if (fileHash.toLowerCase() !== sha256.toLowerCase()) {
       console.log(`Hash mismatch: ${fileHash} !== ${sha256}, deleting file "${metadataFile}"`);
       removeMetadataFile({core}, metadataFile);

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -49,7 +49,7 @@ function checkDownloadedAddonHash({core}, downloadFileName, sha256) {
   });
 }
 
-function checkMetadataDownloadResult({core}, metadataFile, sha256, err, stdout, stderr) {
+function checkMetadataDownloadResult({core}, metadataFile, downloadFileName, sha256, err, stdout, stderr) {
   if (stderr !== '' || err !== null) {
     console.log(`err: ${err}`);
     console.log(`stdout: ${stdout}`);
@@ -73,7 +73,7 @@ function checkMetadataFile({core}, metadataFile) {
     // increase maxBuffer size to 10GB
     { maxBuffer: 1024 * 1024 * 1024 * 10 },
     (err, stdout, stderr) => {
-      checkMetadataDownloadResult({core}, metadataFile, sha256, err, stdout, stderr);
+      checkMetadataDownloadResult({core}, metadataFile, downloadFileName, sha256, err, stdout, stderr);
   });
 }
 

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -60,7 +60,7 @@ function checkMetadataDownloadResult({core}, metadataFile, downloadFileName, sha
     console.log(`stdout: ${stdout}`);
     console.log(`stderr: ${stderr}`);
     // delete file if download failed
-    strippedStderr = stderr.replace("\n", "  ");
+    strippedStderr = stderr.replace("\n", "  ").replace("\r", "");
     removeMetadataFile({core}, metadataFile, `Download failed: ${strippedStderr}`); 
     return;
   }

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -12,7 +12,7 @@ module.exports = ({core}, globPattern) => {
     const sha256 = addonMetadata.sha256;
     const hash = crypto.createHash('sha256');
     exec(
-      `curl --fail --silent --show-error --location --output ${addonId}.nvda-addon "${addonMetadata.URL}"`,
+      `curl --fail --silent --show-error --location --output "${addonId}.nvda-addon" "${addonMetadata.URL}"`,
       // increase maxBuffer size to 10GB
       { maxBuffer: 1024 * 1024 * 1024 * 10 },
       (err, stdout, stderr) => {
@@ -21,7 +21,7 @@ module.exports = ({core}, globPattern) => {
         console.log(`stdout: ${stdout}`);
         console.log(`stderr: ${stderr}`);
         // delete file if download failed
-        exec(`rm ${file}`, (err, stdout, stderr) => {
+        exec(`rm "${file}"`, (err, stdout, stderr) => {
           if (stderr !== '' || err !== null) {
             console.log(`err: ${err}`);
             console.log(`stdout: ${stdout}`);
@@ -41,7 +41,7 @@ module.exports = ({core}, globPattern) => {
       fileStream.on('end', () => {
         const fileHash = hash.digest('hex');
         if (fileHash !== sha256) {
-          exec(`rm ${file}`, (err, stdout, stderr) => {
+          exec(`rm "${file}"`, (err, stdout, stderr) => {
             if (stderr !== '' || err !== null) {
               console.log(`err: ${err}`);
               console.log(`stderr: ${stderr}`);

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -10,7 +10,6 @@ module.exports = ({core}, globPattern) => {
     const addonMetadata = JSON.parse(addonMetadataContents);
     const addonId = addonMetadata.addonId;
     const sha256 = addonMetadata.sha256;
-    const hash = crypto.createHash('sha256');
     exec(
       `curl --fail --silent --show-error --location --output "${addonId}.nvda-addon" "${addonMetadata.URL}"`,
       // increase maxBuffer size to 10GB
@@ -32,6 +31,8 @@ module.exports = ({core}, globPattern) => {
         })
         return;
       }
+      const hash = crypto.createHash('sha256');
+      hash.write("")
       // if hash mismatches, delete the file
       hash.setEncoding('hex');
       const fileStream = fs.createReadStream(`${addonId}.nvda-addon`);
@@ -40,8 +41,9 @@ module.exports = ({core}, globPattern) => {
       });
       fileStream.on('end', () => {
         const fileHash = hash.digest('hex');
+        hash.end();
         if (fileHash.toLowerCase() !== sha256.toLowerCase()) {
-          console.log(`Hash mismatch: ${fileHash} !== ${sha256}, deleting file`);
+          console.log(`Hash mismatch: ${fileHash} !== ${sha256}, deleting file "${file}"`);
           exec(`rm "${file}"`, (err, stdout, stderr) => {
             if (stderr !== '' || err !== null) {
               console.log(`err: ${err}`);

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -9,7 +9,7 @@ function removeMetadataFile({core}, metadataFile, reason) {
   console.log(`Deleting file "${metadataFile}" because ${reason}`);
   exec(`rm "${metadataFile}"`, (err, stdout, stderr) => {
     metadataFileNormalised = metadataFile.replace(/\\/g, '/');
-    core._PRBodyString = core._PRBodyString.concat(`| [${metadataFileNormalised}](${PROJECT_URL}${metadataFileNormalised}) | ${reason} |\n`);
+    core._PRBodyString += `| [${metadataFileNormalised}](${PROJECT_URL}${metadataFileNormalised}) | ${reason} |\n`;
     if (stderr !== '' || err !== null) {
       console.log(`err: ${err}`);
       console.log(`stderr: ${stderr}`);

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -1,5 +1,6 @@
 const glob = require('glob');
 const crypto = require('crypto');
+const uuidv4 = require('uuid/v4');
 
 module.exports = ({core}, globPattern) => {
   const fs = require('fs');
@@ -10,8 +11,9 @@ module.exports = ({core}, globPattern) => {
     const addonMetadata = JSON.parse(addonMetadataContents);
     const addonId = addonMetadata.addonId;
     const sha256 = addonMetadata.sha256;
+    const downloadFileName = `${uuidv4()}.nvda-addon`;
     exec(
-      `curl --fail --silent --show-error --location --output "${addonId}.nvda-addon" "${addonMetadata.URL}"`,
+      `curl --fail --silent --show-error --location --output "${downloadFileName}" "${addonMetadata.URL}"`,
       // increase maxBuffer size to 10GB
       { maxBuffer: 1024 * 1024 * 1024 * 10 },
       (err, stdout, stderr) => {
@@ -35,7 +37,7 @@ module.exports = ({core}, globPattern) => {
       hash.write("")
       // if hash mismatches, delete the file
       hash.setEncoding('hex');
-      const fileStream = fs.createReadStream(`${addonId}.nvda-addon`);
+      const fileStream = fs.createReadStream(downloadFileName);
       fileStream.on('data', chunk => {
         hash.update(chunk);
       });

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -11,6 +11,7 @@ function removeMetadataFile({core}, metadataFile, reason) {
     // stdout is garbage here, so we don't use it
     metadataFileNormalised = metadataFile.replace(/\\/g, '/');
     core._PRBodyString += `| [${metadataFileNormalised}](${PROJECT_URL}${metadataFileNormalised}) | ${reason} |\n`;
+    core.setOutput("PRBodyString", core._PRBodyString);
     if (stderr !== '' || err !== null) {
       console.log(`err: ${err}`);
       console.log(`stderr: ${stderr}`);
@@ -87,5 +88,4 @@ module.exports = ({core}, globPattern) => {
   metadataFiles.forEach(metadataFile => {
     checkMetadataFile({core}, metadataFile);
   });
-  core.setOutput("PRBodyString", core._PRBodyString);
 };

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -27,7 +27,7 @@ module.exports = ({core}, globPattern) => {
             console.log(`err: ${err}`);
             console.log(`stdout: ${stdout}`);
             console.log(`stderr: ${stderr}`);
-            core.setFailed('Failed to delete add-on file');
+            core.setFailed(`Failed to delete add-on file: ${file}`);
             return;
           }
         })
@@ -45,13 +45,23 @@ module.exports = ({core}, globPattern) => {
       fileStream.on('end', () => {
         const fileHash = hash.digest('hex');
         hash.end();
+        // delete downloaded file
+        exec(`rm "${downloadFileName}"`, (err, stdout, stderr) => {
+          if (stderr !== '' || err !== null) {
+            console.log(`err: ${err}`);
+            console.log(`stdout: ${stdout}`);
+            console.log(`stderr: ${stderr}`);
+            console.error(`Failed to delete downloaded add-on file for ${file}`);
+            return;
+          }
+        })
         if (fileHash.toLowerCase() !== sha256.toLowerCase()) {
           console.log(`Hash mismatch: ${fileHash} !== ${sha256}, deleting file "${file}"`);
           exec(`rm "${file}"`, (err, stdout, stderr) => {
             if (stderr !== '' || err !== null) {
               console.log(`err: ${err}`);
               console.log(`stderr: ${stderr}`);
-              core.setFailed('Failed to delete add-on file');
+              core.setFailed(`Failed to delete add-on file: ${file}`);
               return;
             }
           })

--- a/.github/workflows/checkAddonUrlAndHash.js
+++ b/.github/workflows/checkAddonUrlAndHash.js
@@ -7,11 +7,12 @@ const PROJECT_URL = "https://github.com/nvaccess/addon-datastore/blob/master/";
 
 function removeMetadataFile({core}, metadataFile, reason) {
   console.log(`Deleting file "${metadataFile}" because ${reason}`);
+  // normalise the Windows-style path to be usable for the URL in the PR body
+  const metadataFileNormalised = metadataFile.replace(/\\/g, '/');
+  core._PRBodyString += `| [${metadataFileNormalised.replace("addons/", "")}](${PROJECT_URL}${metadataFileNormalised}) | ${reason} |\n`;
+  core.setOutput("PRBodyString", core._PRBodyString);
   exec(`rm "${metadataFile}"`, (err, stdout, stderr) => {
     // stdout is garbage here, so we don't use it
-    metadataFileNormalised = metadataFile.replace(/\\/g, '/');
-    core._PRBodyString += `| [${metadataFileNormalised.replace("addons/", "")}](${PROJECT_URL}${metadataFileNormalised}) | ${reason} |\n`;
-    core.setOutput("PRBodyString", core._PRBodyString);
     if (stderr !== '' || err !== null) {
       console.log(`err: ${err}`);
       console.log(`stderr: ${stderr}`);
@@ -23,9 +24,9 @@ function removeMetadataFile({core}, metadataFile, reason) {
 
 function removeDownloadedAddonFile(downloadFileName, metadataFile) {
   exec(`rm "${downloadFileName}"`, (err, stdout, stderr) => {
+    // stdout is garbage here, so we don't use it
     if (stderr !== '' || err !== null) {
       console.log(`err: ${err}`);
-      console.log(`stdout: ${stdout}`);
       console.log(`stderr: ${stderr}`);
       console.error(`Failed to delete downloaded add-on file for ${metadataFile}`);
       return;
@@ -36,7 +37,6 @@ function removeDownloadedAddonFile(downloadFileName, metadataFile) {
 function checkDownloadedAddonHash({core}, downloadFileName, metadataFile, sha256) {
   // if hash mismatches, delete the addon data file
   const hash = crypto.createHash('sha256');
-  hash.write("")
   hash.setEncoding('hex');
   const fileStream = fs.createReadStream(downloadFileName);
   fileStream.on('data', chunk => {
@@ -45,7 +45,7 @@ function checkDownloadedAddonHash({core}, downloadFileName, metadataFile, sha256
   fileStream.on('end', () => {
     const fileHash = hash.digest('hex');
     hash.end();
-    // delete downloaded file
+    // Clean up the downloaded file
     removeDownloadedAddonFile(downloadFileName, metadataFile);
     if (fileHash.toLowerCase() !== sha256.toLowerCase()) {
       removeMetadataFile({core}, metadataFile, `Hash mismatch ${fileHash} (actual) != ${sha256} (expected)`);
@@ -55,12 +55,13 @@ function checkDownloadedAddonHash({core}, downloadFileName, metadataFile, sha256
 }
 
 function checkMetadataDownloadResult({core}, metadataFile, downloadFileName, sha256, err, stdout, stderr) {
+  // if download fails, delete the addon metadata file
   if (stderr !== '' || err !== null) {
     console.log(`err: ${err}`);
     console.log(`stdout: ${stdout}`);
     console.log(`stderr: ${stderr}`);
-    // delete file if download failed
-    strippedStderr = stderr.replace("\n", "  ").replace("\r", "");
+    // strip newlines and carriage returns from stderr to avoid breaking the markdown table
+    const strippedStderr = stderr.replace("\n", "  ").replace("\r", "");
     removeMetadataFile({core}, metadataFile, `Download failed: ${strippedStderr}`); 
     return;
   }
@@ -68,15 +69,17 @@ function checkMetadataDownloadResult({core}, metadataFile, downloadFileName, sha
   checkDownloadedAddonHash({core}, downloadFileName, metadataFile, sha256);
 }
 
-function checkMetadataFile({core}, metadataFile) {
+function checkAddonDownload({core}, metadataFile) {
   const addonMetadataContents = fs.readFileSync(metadataFile);
   const addonMetadata = JSON.parse(addonMetadataContents);
   const sha256 = addonMetadata.sha256;
+  // We need a unique name otherwise we could overwrite files
   const downloadFileName = `${uuidv4()}.nvda-addon`;
   // if download fails, delete the addon data file
   exec(
     `curl --fail --silent --show-error --location --output "${downloadFileName}" "${addonMetadata.URL}"`,
-    // increase maxBuffer size to 10GB
+    // increase maxBuffer size to 10GB as add-on files can be large,
+    // and we need to read the entire file to calculate the hash
     { maxBuffer: 1024 * 1024 * 1024 * 10 },
     (err, stdout, stderr) => {
       checkMetadataDownloadResult({core}, metadataFile, downloadFileName, sha256, err, stdout, stderr);
@@ -84,9 +87,10 @@ function checkMetadataFile({core}, metadataFile) {
 }
 
 module.exports = ({core}, globPattern) => {
+  // We want to build a table of files that are being removed
   core._PRBodyString = "| File | Reason |\n|---|---|\n";
   const metadataFiles = glob.globSync(globPattern);
   metadataFiles.forEach(metadataFile => {
-    checkMetadataFile({core}, metadataFile);
+    checkAddonDownload({core}, metadataFile);
   });
 };

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -41,6 +41,7 @@ jobs:
         git add ./addons/*/*.json
         git commit -m "Delete invalid downloads"
     - name: create PR for deleting invalid downloads
+      if: always()
       run: gh pr create -B master -H delInvalidDownloads --title 'Delete invalid add-ons' --body 'Delete add-ons with invalid download links or invalid file hashes'
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -42,7 +42,7 @@ jobs:
         git commit -m "Delete invalid downloads"
     - name: create PR for deleting invalid downloads
       if: always()
-      run: gh pr create -B ${{ github.base_ref }} -H delInvalidDownloads${{ github.run_number }} --title 'Delete invalid add-ons' --body 'Delete add-ons with invalid download links or invalid file hashes'
+      run: gh pr create -B ${{ github.head_ref }} -H delInvalidDownloads${{ github.run_number }} --title 'Delete invalid add-ons' --body 'Delete add-ons with invalid download links or invalid file hashes'
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout validate repo

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Create validation errors file
       run: echo "" > validationErrors.md
     - name: Install addon download validation dependencies
-      run: npm install glob crypto
+      run: npm install glob crypto uuid
     - name: Delete add-ons with invalid downloads
       if: always()
       id: deleteInvalidDownloads
@@ -47,6 +47,7 @@ jobs:
         title: Delete invalid add-ons
         branch: delInvalidDownloads${{ github.run_number }}
         commit-message: Delete invalid add-ons
+        base: ${{ github.ref_name }}
         body: "Delete add-ons with invalid download links or invalid file hashes"
         author: github-actions <github-actions@github.com>
     - name: Checkout validate repo

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -39,7 +39,7 @@ jobs:
         title: Delete add-ons with invalid downloads
         branch: delInvalidDownloads${{ github.run_number }}
         commit-message: Delete invalid add-ons
-        body: "Delete add-ons with invalid download links or invalid file hashes"
+        body: "${{ steps.deleteInvalidDownloads.outputs.PRBodyString }}"
         author: github-actions <github-actions@github.com>
         add-paths: 'addons/*/*.json'
     - name: Checkout validate repo

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -40,7 +40,6 @@ jobs:
         git checkout -b delInvalidDownloads
         git add ./addons/*/*.json
         git commit -m "Delete invalid downloads"
-        git push
     - name: create PR for deleting invalid downloads
       run: gh pr create -B master -H delInvalidDownloads --title 'Delete invalid add-ons' --body 'Delete add-ons with invalid download links or invalid file hashes'
       env:

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -42,7 +42,7 @@ jobs:
         git commit -m "Delete invalid downloads"
     - name: create PR for deleting invalid downloads
       if: always()
-      run: gh pr create -B ${{ github.head_ref }} -H delInvalidDownloads${{ github.run_number }} --title 'Delete invalid add-ons' --body 'Delete add-ons with invalid download links or invalid file hashes'
+      run: gh pr create -B ${{ github.ref_name }} -H delInvalidDownloads${{ github.run_number }} --title 'Delete invalid add-ons' --body 'Delete add-ons with invalid download links or invalid file hashes'
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout validate repo

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
-        git checkout delInvalidDownloads
+        git checkout -b delInvalidDownloads
         git add ./addons/*/*.json
         git commit -m "Delete invalid downloads"
         git push

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -37,12 +37,12 @@ jobs:
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
-        git checkout -b delInvalidDownloads
+        git checkout -b delInvalidDownloads${{ github.run_number }}
         git add ./addons/*/*.json
         git commit -m "Delete invalid downloads"
     - name: create PR for deleting invalid downloads
       if: always()
-      run: gh pr create -B master -H delInvalidDownloads --title 'Delete invalid add-ons' --body 'Delete add-ons with invalid download links or invalid file hashes'
+      run: gh pr create -B master -H delInvalidDownloads${{ github.run_number }} --title 'Delete invalid add-ons' --body 'Delete add-ons with invalid download links or invalid file hashes'
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout validate repo

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -32,11 +32,11 @@ jobs:
         script: |
           const checkAddonUrlAndHash = require('./.github/workflows/checkAddonUrlAndHash.js')
           checkAddonUrlAndHash({core}, "./addons/*/*.json")
-    - name: create PR for deleting invalid downloads
+    - name: Create PR for deleting invalid downloads
       if: always()
       uses: peter-evans/create-pull-request@v6
       with:
-        title: Delete invalid add-ons
+        title: Delete add-ons with invalid downloads
         branch: delInvalidDownloads${{ github.run_number }}
         commit-message: Delete invalid add-ons
         body: "Delete add-ons with invalid download links or invalid file hashes"

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -22,6 +22,29 @@ jobs:
         ref: ${{ inputs.headRef }}
     - name: Create validation errors file
       run: echo "" > validationErrors.md
+    - name: Install addon download validation dependencies
+      run: npm install glob crypto
+    - name: Delete add-ons with invalid downloads
+      if: always()
+      id: deleteInvalidDownloads
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const checkAddonUrlAndHash = require('./.github/workflows/checkAddonUrlAndHash.js')
+          checkAddonUrlAndHash({core}, "./addons/*/*.json")
+    - name: Commit and push changes
+      if: always()
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git checkout delInvalidDownloads
+        git add ./addons/*/*.json
+        git commit -m "Delete invalid downloads"
+        git push
+    - name: create PR for deleting invalid downloads
+      run: gh pr create -B master -H delInvalidDownloads --title 'Delete invalid add-ons' --body 'Delete add-ons with invalid download links or invalid file hashes'
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout validate repo
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -42,9 +42,13 @@ jobs:
         git commit -m "Delete invalid downloads"
     - name: create PR for deleting invalid downloads
       if: always()
-      run: gh pr create -B ${{ github.ref_name }} -H delInvalidDownloads${{ github.run_number }} --title 'Delete invalid add-ons' --body 'Delete add-ons with invalid download links or invalid file hashes'
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: peter-evans/create-pull-request@v6
+      with:
+        title: Delete invalid add-ons
+        branch: delInvalidDownloads${{ github.run_number }}
+        commit-message: Delete invalid add-ons
+        body: "Delete add-ons with invalid download links or invalid file hashes"
+        author: github-actions <github-actions@github.com>
     - name: Checkout validate repo
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -42,7 +42,7 @@ jobs:
         git commit -m "Delete invalid downloads"
     - name: create PR for deleting invalid downloads
       if: always()
-      run: gh pr create -B master -H delInvalidDownloads${{ github.run_number }} --title 'Delete invalid add-ons' --body 'Delete add-ons with invalid download links or invalid file hashes'
+      run: gh pr create -B ${{ github.base_ref }} -H delInvalidDownloads${{ github.run_number }} --title 'Delete invalid add-ons' --body 'Delete add-ons with invalid download links or invalid file hashes'
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout validate repo

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Create validation errors file
       run: echo "" > validationErrors.md
     - name: Install addon download validation dependencies
-      run: npm install glob crypto uuid
+      run: npm install glob uuid
     - name: Delete add-ons with invalid downloads
       if: always()
       id: deleteInvalidDownloads

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -32,14 +32,6 @@ jobs:
         script: |
           const checkAddonUrlAndHash = require('./.github/workflows/checkAddonUrlAndHash.js')
           checkAddonUrlAndHash({core}, "./addons/*/*.json")
-    - name: Commit and push changes
-      if: always()
-      run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git checkout -b delInvalidDownloads${{ github.run_number }}
-        git add ./addons/*/*.json
-        git commit -m "Delete invalid downloads"
     - name: create PR for deleting invalid downloads
       if: always()
       uses: peter-evans/create-pull-request@v6
@@ -47,9 +39,9 @@ jobs:
         title: Delete invalid add-ons
         branch: delInvalidDownloads${{ github.run_number }}
         commit-message: Delete invalid add-ons
-        base: ${{ github.ref_name }}
         body: "Delete add-ons with invalid download links or invalid file hashes"
         author: github-actions <github-actions@github.com>
+        add-paths: 'addons/*/*.json'
     - name: Checkout validate repo
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
a lot of add-on metadata is invalid, causing the monthly check to fail.
Most of this is due to add-on links 404ing or no longer having a matching SHA.

This updates our monthly validation check to open a PR to trim add-ons which have invalid download.

Successful run: https://github.com/nvaccess/addon-datastore/actions/runs/10788921857/job/29920744582 (note other validation errors still exist and need to be fixed)

Example PR (which should be merged after this): #4265
