### PR TITLE
Force push when creating an add-on submission on resubmissions

### DIFF
--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -85,7 +85,8 @@ jobs:
         git pull
         git add .
         git commit -m "Submit add-on"
-        git push origin ${{ github.event.issue.user.login }}${{ steps.get-data.outputs.issueNumber }}
+        # Force push to the branch, as we may need to be handling a resubmission attempt
+        git push -f origin ${{ github.event.issue.user.login }}${{ steps.get-data.outputs.issueNumber }}
     - name: Upload add-on
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
If an add-on submission fails, the branch is often left around, even if no PR is created. 
This means a reviewer must manually delete the branch when resubmitting the add-on.

Instead we can force push on resubmission to the branch