### PR TITLE
Create PR for normalizing files when validating

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -119,7 +119,7 @@ jobs:
           "
 
           mv submitters.json submitters.old.json
-          jq -e "$jqCode" submitters.old.json > submitters.json
+          jq -e --tab "$jqCode" submitters.old.json > submitters.json
           jqExitCode=$?
           rm submitters.old.json
           exit $jqExitCode
@@ -401,7 +401,7 @@ jobs:
         "
   
         mv discussions.json discussions.old.json
-        jq -e "$jqCode" discussions.old.json > discussions.json
+        jq -e --tab "$jqCode" discussions.old.json > discussions.json
         jqExitCode=$?
         rm discussions.old.json
         exit $jqExitCode
@@ -422,7 +422,7 @@ jobs:
         "
   
         mv $addonFilename $addonFilename.old.json
-        jq -e -a "$jqCode" $addonFilename.old.json > $addonFilename
+        jq -e --tab "$jqCode" $addonFilename.old.json > $addonFilename
         jqExitCode=$?
         rm $addonFilename.old.json
         exit $jqExitCode

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -42,6 +42,22 @@ jobs:
         body: "${{ steps.deleteInvalidDownloads.outputs.PRBodyString }}"
         author: github-actions <github-actions@github.com>
         add-paths: 'addons/*/*.json'
+    - name: Normalize JSON files with jq
+      run: |
+        for file in $(find ./addons -name '*.json'); do
+          jq --tab . $file > $file.tmp
+          mv $file.tmp $file
+        done
+    - name: Create PR for normalizing files
+      if: always()
+      uses: peter-evans/create-pull-request@v6
+      with:
+        title: Normalize JSON files
+        branch: normJSON${{ github.run_number }}
+        commit-message: Normalize JSON files
+        body: "Use tabs and unicode encoding for JSON files"
+        author: github-actions <github-actions@github.com>
+        add-paths: 'addons/*/*.json'
     - name: Checkout validate repo
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -45,9 +45,9 @@ jobs:
     - name: Normalize JSON files with jq
       shell: bash
       run: |
-        for file in $(find ./addons -name '*.json'); do
-          jq --tab . "$file" > "$file.tmp"
-          mv "$file.tmp" "$file"
+        for file in ./addons/*/*.json; do
+            jq --tab . "${file}" > "${file}.tmp"
+            mv "${file}.tmp" "${file}"
         done
     - name: Create PR for normalizing files
       if: always()

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -46,8 +46,8 @@ jobs:
       shell: bash
       run: |
         for file in $(find ./addons -name '*.json'); do
-          jq --tab . $file > $file.tmp
-          mv $file.tmp $file
+          jq --tab . "$file" > "$file.tmp"
+          mv "$file.tmp" "$file"
         done
     - name: Create PR for normalizing files
       if: always()

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -43,6 +43,7 @@ jobs:
         author: github-actions <github-actions@github.com>
         add-paths: 'addons/*/*.json'
     - name: Normalize JSON files with jq
+      shell: bash
       run: |
         for file in $(find ./addons -name '*.json'); do
           jq --tab . $file > $file.tmp


### PR DESCRIPTION
Add-on files use a mixture of tabs and spaces. They also use a mix of unicode and ascii escape sequences of unicode characters e.g. `\u1452`.

Instead, when validating files, a PR should be opened to normalize these all to tabs and unicode.
Additionally `jq` code which was introducing these inconsistencies has been fixed up.

Successful run: https://github.com/nvaccess/addon-datastore/actions/runs/10935530692/job/30357445381
Successful PR: https://github.com/nvaccess/addon-datastore/pull/4312