### PR TITLE
Create status badges for workflow runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ Please note: the NVDA project including the Add-on Store has a [Citizen and Cont
 NV Access expects that all contributors and other community members will read and abide by the rules set out in this document while participating in the project or contributing add-ons.
 
 ## Guide for submitters
+
 Add-on authors who wish to have their add-on distributed through the Add-on Store should refer to [the submission guide](./docs/submitters/submissionGuide.md).
 
 ## Design overview
+
 For an overview of the whole Add-on Store, read [the design overview](./docs/design/designOverview.md).
 
 ### About security 
+
 Add-ons are run at user's own risk, add-ons in the add-on store do not undergo human security audits.
 The add-on store includes the following security measures:
 
@@ -37,6 +40,7 @@ Add-ons which are malicious or otherwise break the code of conduct can be remove
   - Sending an email to <info@nvaccess.org>
 
 ## Non-exclusivity
+
 This system does not restrict add-on authors from developing, publishing, and distributing an add-on outside this store.
 NVDA will still allow local installation from a `*.nvda-addon` file.
 The data hosted here is distributed under the [ODC-PDDL](https://opendatacommons.org/licenses/pddl/1-0/) license.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ These views are hosted on the NV Access server and are available in the NVDA Add
 Please note: the NVDA project including the Add-on Store has a [Citizen and Contributor Code of Conduct](https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md).
 NV Access expects that all contributors and other community members will read and abide by the rules set out in this document while participating in the project or contributing add-ons.
 
-### Guide for submitters
+## Guide for submitters
 Add-on authors who wish to have their add-on distributed through the Add-on Store should refer to [the submission guide](./docs/submitters/submissionGuide.md).
 
-### Design overview
+## Design overview
 For an overview of the whole Add-on Store, read [the design overview](./docs/design/designOverview.md).
 
 ### About security 
@@ -25,8 +25,7 @@ If malicious content is detected, the add-on will not be automatically included 
 Please contact the flagged security vendors to get them to review and unflag the false positive. 
 Please email info@nvaccess.org if you need assistance with this process.
 
-
-### Human review process / code audit
+## Human review process / code audit
 - NV Access doesn't require a manual review of the add-on (code or user experience) itself before the add-on submission.
 - NV Access manually maintains a list of approved submitters with permission to submit an add-on to the store.
 The process NV Access follows is described [here](./docs/dev/submissionReview.md#approving-an-author-to-submit-to-a-particular-add-on-id-for-the-first-time).
@@ -37,8 +36,13 @@ Add-ons which are malicious or otherwise break the code of conduct can be remove
   - Opening a pull request to remove the submitted add-on metadata
   - Sending an email to <info@nvaccess.org>
 
-### Non-exclusivity
+## Non-exclusivity
 This system does not restrict add-on authors from developing, publishing, and distributing an add-on outside this store.
 NVDA will still allow local installation from a `*.nvda-addon` file.
 The data hosted here is distributed under the [ODC-PDDL](https://opendatacommons.org/licenses/pddl/1-0/) license.
 A plain language summary can be found [here](https://opendatacommons.org/licenses/pddl/summary/).
+
+## Status badges
+
+- Status for latest submitted add-on: [![view submissions](https://github.com/nvaccess/addon-datastore/actions/workflows/sendJsonFile.yml/badge.svg)](https://github.com/nvaccess/addon-datastore/actions/workflows/sendJsonFile.yml)
+- Status for validating all submitted add-ons: [![view validation attempts](https://github.com/nvaccess/addon-datastore/actions/workflows/validateAllAddons.yml/badge.svg)](https://github.com/nvaccess/addon-datastore/actions/workflows/validateAllAddons.yml)


### PR DESCRIPTION
Creates status badges with alt text, that link to the workflow runs of 2 important add-on actions.
- latest add-on submission, this ensures there's been a successful submission with transform. It's might be okay if this is failing, it could mean the most recent add-on had validation issues
- latest validation of all add-ons - this should always be successful as of recent PRs to normalize and fix validation errors

Also fixes heading structure 