### PR TITLE
Revert "Add DarkoMilosevic86 as an approved submitter for WasapiSoundRecorder"

### DIFF
--- a/submitters.json
+++ b/submitters.json
@@ -588,8 +588,7 @@
 	},
 	"12859957": {
 		"addons": [
-			"BluetoothAudioActive",
-			"WasapiSoundRecorder"
+			"BluetoothAudioActive"
 		],
 		"githubName": "DarkoMilosevic86"
 	},


### PR DESCRIPTION
Reverts nvaccess/addon-datastore#4984

Previous submission addonID was altered: https://github.com/nvaccess/addon-datastore/issues/4983#issuecomment-2641638680