### PR TITLE
Add specialCharacter addon to addonsIndex.json

### DIFF
--- a/addons/specialCharacter.json
+++ b/addons/specialCharacter.json
@@ -1,0 +1,22 @@
+{
+  "addon_id": "specialCharacter",
+  "addon_name": {
+    "en": "specialCharacter"
+  },
+  "addon_description": {
+    "en": "This add-on helps you type 26 commonly used special characters without remembering Alt codes."
+  },
+  "addon_version": "2025.2",
+  "addon_author": "chai chaimee",
+  "addon_url": "https://github.com/chaichaimee/specialCharacter",
+  "addon_download_url": "https://github.com/chaichaimee/specialCharacter/releases/download/2025.2/specialCharacter-2025.2.nvda-addon",
+  "addon_min_nvda_version": "2022.4",
+  "addon_last_tested_nvda_version": "2025.1",
+  "addon_status": "stable",
+  "addon_doc_file_name": "readme.html",
+  "addon_update_channel": null,
+  "addon_supported_languages": [
+    "en"
+  ]
+}
+      

--- a/new specialCharacter.json
+++ b/new specialCharacter.json
@@ -1,0 +1,21 @@
+{
+  "addon_id": "specialCharacter",
+  "addon_name": {
+    "en": "Special Character"
+  },
+  "addon_description": {
+    "en": "This add-on helps you type 26 commonly used special characters without remembering Alt codes."
+  },
+  "addon_version": "2025.2",
+  "addon_author": "Chai Chaimee (chaicm75@gmail.com)",
+  "addon_url": "https://github.com/chaichaimee/specialCharacter",
+  "addon_download_url": "https://github.com/chaichaimee/specialCharacter/releases/download/2025.2/specialCharacter-2025.2.nvda-addon",
+  "addon_min_nvda_version": "2022.4",
+  "addon_last_tested_nvda_version": "2025.1",
+  "addon_status": "stable",
+  "addon_doc_file_name": "readme.html",
+  "addon_update_channel": null,
+  "addon_supported_languages": [
+    "en",
+    
+}

--- a/specialCharacter.json
+++ b/specialCharacter.json
@@ -1,0 +1,22 @@
+{
+  "addon_id": "specialCharacter",
+  "addon_name": {
+    "en": "specialCharacter"
+  },
+  "addon_description": {
+    "en": "This add-on helps you type 26 commonly used special characters without remembering Alt codes."
+  },
+  "addon_version": "2025.2",
+  "addon_author": "chai chaimee",
+  "addon_url": "https://github.com/chaichaimee/specialCharacter",
+  "addon_download_url": "https://github.com/chaichaimee/specialCharacter/releases/download/2025.2/specialCharacter-2025.2.nvda-addon",
+  "addon_min_nvda_version": "2022.4",
+  "addon_last_tested_nvda_version": "2025.1",
+  "addon_status": "stable",
+  "addon_doc_file_name": "readme.html",
+  "addon_update_channel": null,
+  "addon_supported_languages": [
+    "en"
+  ]
+}
+


### PR DESCRIPTION
This pull request adds the specialCharacter addon to the addonsIndex.json file for inclusion in the NVDA add-on store.

Addon details:
- Addon name: specialCharacter
- Description: This add-on helps users type 26 commonly used special characters without remembering Alt codes.
- Version: 2025.2
- Minimum NVDA version: 2022.4
- Last tested NVDA version: 2025.1
- Status: Stable
