### PR TITLE
Revert "Add wl-fw as an approved submitter for net_speed_counter"

### DIFF
--- a/submitters.json
+++ b/submitters.json
@@ -736,11 +736,5 @@
 			"KeyboardShortcutsAutocompletePro"
 		],
 		"githubName": "Mohammedkhaled96"
-	},
-	"194633229": {
-		"addons": [
-			"net_speed_counter"
-		],
-		"githubName": "wl-fw"
 	}
 }


### PR DESCRIPTION
Reverts nvaccess/addon-datastore#6074
Reason: https://github.com/nvaccess/addon-datastore/issues/6075#issuecomment-3055650649