### PR TITLE
Add submitter entry for sarperarikan

### DIFF
--- a/submitters.json
+++ b/submitters.json
@@ -855,5 +855,13 @@
 			"youtubeDownloader"
 		],
 		"githubName": "beyondsighttech"
-	}
+	},
+	"14987303": {
+  "addons": [
+    "visionAccess"
+  ],
+  "githubName": "sarperarikan",
+  "url": "https://github.com/sarperarikan"
+}
+
 }


### PR DESCRIPTION
This PR adds submitter metadata for Sarper Arıkan, developer of the VisionAccess NVDA add-on.
