### PR TITLE
New submission: ojsMonitor 1.0.0

### DIFF
--- a/submissions/ojsMonitor.json
+++ b/submissions/ojsMonitor.json
@@ -1,0 +1,6 @@
+{
+    "id": "ojsMonitor",
+    "repository": "mpquemel/ojsMonitor",
+    "ref": "v1.0.0",
+    "sha256": "93f782e3241e4d6145fbc268dc457c0a07daaba81bdc4f9c5bd3ffa98bd781f0"
+}


### PR DESCRIPTION
### Link to download the add-on package: https://github.com/mpquemel/ojsMonitor/releases/download/v1.0.0/ojsMonitor-1.0.0.nvda-addon
### SHA256 sum: 93f782e3241e4d6145fbc268dc457c0a07daaba81bdc4f9c5bd3ffa98bd781f0
### Checklist:
- [x] The new add-on/version has been tested on a clean portable version of NVDA and functions as expected.
- [x] The API endpoint for the download URL (if applicable) is valid.
- [x] The sha256 sum is correct.
- [x] The manifest 'name' key matches the id in the json filename.