### PR TITLE
Add nvdaCoach 1.0.0

### DIFF
--- a/addons/nvdaCoach/1.0.0.json
+++ b/addons/nvdaCoach/1.0.0.json
@@ -1,0 +1,26 @@
+{
+  "addonId": "nvdaCoach",
+  "addonVersionName": "1.0.0",
+  "addonVersionNumber": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "displayName": "NVDA Coach",
+  "description": "An interactive, in-NVDA training system that teaches screen reader commands through guided, hands-on drills with real-time feedback. Built by an assistive technology instructor for absolute beginners.",
+  "author": "Tony Gebhard",
+  "homepage": "https://tonygebhard.me/NVDACoach",
+  "minNVDAVersion": {
+    "major": 2024,
+    "minor": 1,
+    "patch": 0
+  },
+  "lastTestedVersion": {
+    "major": 2025,
+    "minor": 1,
+    "patch": 0
+  },
+  "channel": "stable",
+  "URL": "https://github.com/tonygeb23/nvdaCoach-/releases/download/v1.0.0/nvdaCoach-1.0.0.nvda-addon",
+  "sha256": "fed8d879a72c5082d8a06ce0cb10b5b5d0d3f03089a35635645601f9a359f97f"
+}


### PR DESCRIPTION
Submitting NVDA Coach 1.0.0 to the NVDA Add-on Store.

NVDA Coach is a free interactive training add-on that teaches NVDA screen reader commands through guided, step-by-step practice sessions built into NVDA itself. Designed for absolute beginners and assistive technology instructors.

- 24 lessons across 3 chapters
- Inline practice text areas (no switching apps)
- Live accessible practice forms
- Practice web page for browse mode lessons
- Progress tracking saved across NVDA restarts
- Instructor-extensible via plain JSON lesson files