### PR TITLE
[Submit add-on]: Forza Precision Telemetry Announcer 1.0

### DIFF
--- a/addons/forza_precision_telemetry/1.0.0.json
+++ b/addons/forza_precision_telemetry/1.0.0.json
@@ -1,14 +1,14 @@
 {
 	"addonId": "forza_precision_telemetry",
 	"displayName": "Forza Precision Telemetry Announcer",
-	"URL": "https://github.com/eyupensarr3458-stack/forza-motorsport-speedometer/releases/download/v4.0.3/forza_precision_telemetry-4.0.3.nvda-addon",
+	"URL": "https://github.com/eyupensarr3458-stack/forza-motorsport-speedometer/releases/download/v1.0/forza_precision_telemetry-1.0.nvda-addon",
 	"description": "Announces speed for Forza Motorsport when pressing Alt + A. In Forza Motorsport, open Gameplay > Data Out, enable Data Out, set Data Out IP Address to your IPv4 address, set port to 5300, and set Data Out Package Format to Car Dash.",
-	"sha256": "70ee557ecfd5f73ec90a1ce630ff52bbde52fa855be77bd15e08e29ed56c0537",
-	"addonVersionName": "4.0.3",
+	"sha256": "17109e06aade6a2c3b6ff77f37c08d042dab42e8efa35578bf35cfe507397b1b",
+	"addonVersionName": "1.0",
 	"addonVersionNumber": {
-		"major": 4,
+		"major": 1,
 		"minor": 0,
-		"patch": 3
+		"patch": 0
 	},
 	"minNVDAVersion": {
 		"major": 2021,
@@ -22,9 +22,9 @@
 	},
 	"channel": "stable",
 	"publisher": "Antigravity & User",
-	"sourceURL": "https://github.com/eyupensarr3458-stack/forza-motorsport-speedometer/tree/v4.0.3",
+	"sourceURL": "https://github.com/eyupensarr3458-stack/forza-motorsport-speedometer/tree/v1.0",
 	"license": "GPL v2",
 	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html",
-	"submissionTime": 1773369860000,
+	"submissionTime": 1773373340000,
 	"translations": []
 }


### PR DESCRIPTION
Manual datastore submission for Forza Precision Telemetry Announcer 1.0.

Reason for manual PR: the public issue-form submission could be created, but GitHub did not apply the template label for an external contributor, so the datastore workflow never triggered automatically.

This revision supersedes the earlier 4.x draft submissions, sets the public add-on version to 1.0, and includes the required Forza Motorsport setup instructions in the store-visible description:
- Open Gameplay > Data Out
- Enable Data Out
- Set Data Out IP Address to the user's IPv4 address
- Set port to 5300
- Set Data Out Package Format to Car Dash

Release asset:
https://github.com/eyupensarr3458-stack/forza-motorsport-speedometer/releases/download/v1.0/forza_precision_telemetry-1.0.nvda-addon

Source:
https://github.com/eyupensarr3458-stack/forza-motorsport-speedometer/tree/v1.0

Local datastore validation passed before updating this PR.