### PR TITLE
Add ClimaSpeak 2026.03.20

### DIFF
--- a/climaspeak/2026.3.20.json
+++ b/climaspeak/2026.3.20.json
@@ -1,15 +1,15 @@
 {
 	"addonId": "climaspeak",
 	"displayName": "ClimaSpeak",
-	"URL": "https://github.com/GaryMp/clima_speak/releases/download/2026.03.19/climaspeak-2026.03.19.nvda-addon",
+	"URL": "https://github.com/GaryMp/clima_speak/releases/download/2026.03.20/climaspeak-2026.03.20.nvda-addon",
 	"description": "Add-on to announce weather information.",
-	"sha256": "869ecbb054e4311081e6825ae8fa47dc718380a865ce70a07a7c31554ccbd485",
-	"homepage": "https://github.com/GaryMp/clima_speak",
-	"addonVersionName": "2026.03.19",
+	"sha256": "e25fe2893ea3f32bd41ff7c777e8dd1782e8b742f0c3906d3edb61e81b40a484",
+	"homepage": "https://github.com/GaryMp/climaspeak",
+	"addonVersionName": "2026.03.20",
 	"addonVersionNumber": {
 		"major": 2026,
 		"minor": 3,
-		"patch": 19
+		"patch": 20
 	},
 	"minNVDAVersion": {
 		"major": 2019,
@@ -22,8 +22,8 @@
 		"patch": 0
 	},
 	"channel": "stable",
-	"publisher": "Gary Darío Muñoz Peña",
-	"sourceURL": "https://github.com/GaryMp/clima_speak",
+	"publisher": "",
+	"sourceURL": "https://github.com/GaryMp/climaspeak",
 	"license": "GPL 2",
 	"licenseURL": "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
 }


### PR DESCRIPTION
Add ClimaSpeak add-on to the NVDA Add-on Store.
  ClimaSpeak announces weather information using keyboard gestures, fetching data from        
  wttr.in.
  