### PR TITLE
move create review comment to happen on PR

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -413,8 +413,12 @@ jobs:
         git config user.name github-actions
         git config user.email github-actions@github.com
         git add .
-        git commit -m "update discussion URL"
-        git push --set-upstream origin ${{ env.branchName }}
+        if git diff --staged --quiet; then
+          echo "No staged changes; skipping commit and push."
+        else
+          git commit -m "update discussion URL"
+          git push --set-upstream origin ${{ env.branchName }}
+        fi
 
   mergeToMaster:
     needs: [getAddonId, commitScanResults, createReviewComment, createPullRequest, requireManualApproval]


### PR DESCRIPTION
This pull request restructures the GitHub Actions workflow in `.github/workflows/checkAndSubmitAddonMetadata.yml` to improve the sequencing and dependencies of jobs related to merging pull requests and creating review comments. The main changes involve moving the `mergeToMaster` job to occur after review comments are created, updating job dependencies and conditions, and ensuring branches are pushed correctly.
This avoids committing directly to master which is discouraged.


Workflow job sequencing and dependencies:

* The `mergeToMaster` job is now executed after the `createReviewComment` job, ensuring that review comments are created before merging to master. Its dependencies and conditions have been updated to require successful completion of `createReviewComment` and other prerequisite jobs.
* The `createReviewComment` job's dependencies and conditions have been updated to remove its reliance on `mergeToMaster` and instead depend on `requireManualApproval` and `commitScanResults`, ensuring it runs before the merge.
* The `call-workflow` job now depends on the successful completion of `mergeToMaster` instead of `createReviewComment`, reflecting the new workflow order.

Branch handling improvements:

* The code now checks out and pushes to the correct branch using the `${{ env.branchName }}` variable instead of the default branch or `github.ref`, ensuring that changes are correctly associated with the intended branch throughout the workflow. [[1]](diffhunk://#diff-4b863d4526c40d7948b8ebce229eaa446624af61bb5e2766f832d9642f6699e3L350-R331) [[2]](diffhunk://#diff-4b863d4526c40d7948b8ebce229eaa446624af61bb5e2766f832d9642f6699e3L436-R440)

These changes make the workflow more robust by ensuring that review comments are always created before merging, and that branch operations are handled consistently.

