### PR TITLE
Create a PR when regenerating rather than committing directly

### DIFF
--- a/.github/workflows/regenerateJson.yml
+++ b/.github/workflows/regenerateJson.yml
@@ -31,10 +31,11 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         $baseBranch = "${{ github.ref_name }}"
-        $headBranch = "regenJson${{ github.run_number }}"
+        $headBranch = "regenJson${{ github.run_id }}-${{ github.run_attempt }}"
 
         git add addons
-        if (git diff --staged --quiet) {
+        git diff --staged --quiet
+        if ($LASTEXITCODE -eq 0) {
           echo "No changes to commit; skipping PR creation."
         } else {
           git config user.name "github-actions"
@@ -43,12 +44,13 @@ jobs:
           git commit -m "[Automated] Regenerate json files"
           git push --set-upstream origin $headBranch
 
-          gh pr create `
-            --squash `
+          $prUrl = gh pr create `
             --base $baseBranch `
             --head $headBranch `
             --title "[Automated] Regenerate json files" `
             --body "Regenerated json files for add-ons. Triggered from workflow run ${{ github.run_id }}."
+
+          gh pr merge $prUrl --squash --delete-branch
         }
     - name: Upload validation errors as artifact
       if: failure()


### PR DESCRIPTION
Avoiding committing directly to the branch (e.g. master) when regenerating add-on metadata.

As this could run from a branch of master, we don't always want to call a transform to views after. That can be run manually from a separate workflow if required

