### PR TITLE
Update build-discussion action to v2

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -346,7 +346,7 @@ jobs:
     - name: Create discussion for add-on id
       id: createDiscussion
       if: ${{ ! fromJSON(steps.checkDiscussion.outputs.jqStatus) }}
-      uses: nvdaes/build-discussion@v1
+      uses: nvdaes/build-discussion@v2
       with:
         category-position: 1
         title: Reviews for ${{ steps.getAddonNameAndVersion.outputs.addonName }} (${{ needs.getAddonId.outputs.addonId }})


### PR DESCRIPTION
### Summary of the issue

I've updated nvdaes/build-discussion action to v2, transforming the JavaScript action to composite using a bash script, to be able to maintain it without dealing with dependencies. I'm using GH CLI, as recently done in nvdal10nUtil for releases.
### Development approach

Bump version.

### Testing performed

I've setup pre-commit with linters for Bash script and markdown, as well as the ci (integration previous check), which creates a discussion on push to main and on pull request.

###

Repo: https://github.com/nvdaes/build-discussion