### PR TITLE
Fix views push token inheritance

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -18,6 +18,8 @@ on:
     secrets:
       VT_API_KEY:
         required: true
+      VIEWS_PUSH_TOKEN:
+        required: true
 
 env:
   branchName: ${{ inputs.issueAuthorName }}${{ inputs.issueNumber }}
@@ -443,3 +445,5 @@ jobs:
     needs: [mergeToMaster]
     if: ${{ always() && needs.mergeToMaster.result == 'success' }}
     uses: ./.github/workflows/transformDataToViews.yml
+    secrets:
+      VIEWS_PUSH_TOKEN: ${{ secrets.VIEWS_PUSH_TOKEN }}

--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -105,3 +105,4 @@ jobs:
       issueTitle: ${{ github.event.issue.title }}
     secrets:
       VT_API_KEY: ${{ secrets.VT_API_KEY }}
+      VIEWS_PUSH_TOKEN: ${{ secrets.VIEWS_PUSH_TOKEN }}

--- a/.github/workflows/transformDataToViews.yml
+++ b/.github/workflows/transformDataToViews.yml
@@ -2,6 +2,10 @@ name: Transform NVDA addons to views
 
 on:
   workflow_call:
+    secrets:
+      VIEWS_PUSH_TOKEN:
+        description: Token with access to nvaccess/addonstore-views
+        required: true
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to support a new secret, `VIEWS_PUSH_TOKEN`, which is required for pushing to the `nvaccess/addonstore-views` repository. The changes ensure that this secret is properly defined, passed, and required in all relevant workflows.

Secret management improvements:

* Added `VIEWS_PUSH_TOKEN` as a required secret in `.github/workflows/checkAndSubmitAddonMetadata.yml` and `.github/workflows/transformDataToViews.yml`, and ensured it is passed to jobs that require it. [[1]](diffhunk://#diff-4b863d4526c40d7948b8ebce229eaa446624af61bb5e2766f832d9642f6699e3R21-R22) [[2]](diffhunk://#diff-98e992d62088bd692f1bc13280e2674b423e6861c1a9ec309b895ad713046d55R5-R8)
* Updated jobs in `.github/workflows/checkAndSubmitAddonMetadata.yml` and `.github/workflows/sendJsonFile.yml` to pass the `VIEWS_PUSH_TOKEN` secret to downstream workflows and jobs. [[1]](diffhunk://#diff-4b863d4526c40d7948b8ebce229eaa446624af61bb5e2766f832d9642f6699e3R448-R449) [[2]](diffhunk://#diff-676fb38bd015d01c4ceaf27dce3840b653fb8a8f220b07e24707145552fd55eeR108)