### PR TITLE
Hand over permissions in reusable workflows

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -443,6 +443,9 @@ jobs:
 
   call-workflow:
     needs: [mergeToMaster]
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ always() && needs.mergeToMaster.result == 'success' }}
     uses: ./.github/workflows/transformDataToViews.yml
     secrets:

--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -97,6 +97,11 @@ jobs:
       run: vt scan file -k $env:VT_API_KEY addon.nvda-addon
   call-workflow:
     needs: check-addon
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      discussions: write
     uses: ./.github/workflows/checkAndSubmitAddonMetadata.yml
     with:
       issueNumber: "${{ github.event.issue.number }}"


### PR DESCRIPTION
This pull request updates GitHub Actions workflow files to explicitly set required permissions for jobs that call other workflows. This ensures that the workflows have the necessary access to perform actions such as writing to contents, pull requests, issues, and discussions.

**Workflow permissions updates:**

* [`.github/workflows/checkAndSubmitAddonMetadata.yml`](diffhunk://#diff-4b863d4526c40d7948b8ebce229eaa446624af61bb5e2766f832d9642f6699e3R446-R448): Added `contents: write` and `pull-requests: write` permissions to the `call-workflow` job to allow it to modify repository contents and manage pull requests.
* [`.github/workflows/sendJsonFile.yml`](diffhunk://#diff-676fb38bd015d01c4ceaf27dce3840b653fb8a8f220b07e24707145552fd55eeR100-R104): Added `contents: write`, `issues: write`, `pull-requests: write`, and `discussions: write` permissions to the `call-workflow` job to enable it to interact with repository contents, issues, pull requests, and discussions as needed.