### PR TITLE
add faceGuide addon

### DIFF
--- a/addons/faceGuide/1.0.0.json
+++ b/addons/faceGuide/1.0.0.json
@@ -1,0 +1,31 @@
+{
+	"addonId": "faceGuide",
+	"displayName": "FaceGuide",
+	"URL": "https://github.com/rajathtirumangalam/faceGuide/releases/download/v1.0.0/faceGuide.nvda-addon",
+	"description": "FaceGuide is an accessibility-focused NVDA add-on that helps blind and low vision users independently frame selfies using real-time face positioning guidance, lighting analysis, blur detection, and automatic capture.",
+	"sha256": "0d560c30db733ff4a7f14f7bc59cb6267b1fa971197f52b93b573cfd4a846a44",
+	"addonVersionName": "1.0.0",
+	"addonVersionNumber": {
+		"major": 1,
+		"minor": 0,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2024,
+		"minor": 1,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2025,
+		"minor": 3,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "Rajath Tirumangalam",
+	"sourceURL": "https://github.com/rajathtirumangalam/faceGuide",
+	"license": "GPL-2.0",
+	"homepage": "https://github.com/rajathtirumangalam/faceGuide",
+	"licenseURL": "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html",
+	"submissionTime": 1778976000000,
+	"translations": []
+}


### PR DESCRIPTION
This PR adds FaceGuide to the NVDA Add-on Store.
FaceGuide is an accessibility-focused NVDA add-on that helps blind and low vision users independently frame selfies using real-time spoken positioning guidance, lighting analysis, blur detection, and automatic capture.
Additional notes:
• 
Processes camera data locally only