### PR TITLE
Add clipboardHistory 2.0.0

### DIFF
--- a/addons/clipboardHistory/2.0.0.json
+++ b/addons/clipboardHistory/2.0.0.json
@@ -1,0 +1,51 @@
+{
+	"addonId": "clipboardHistory",
+	"displayName": "Clipboard History Manager",
+	"URL": "https://github.com/ahmed-f-elaswar/clipboardHistory/releases/download/v2.0.0/clipboardHistory-2.0.0.nvda-addon",
+	"description": "A Ditto-inspired clipboard history manager for NVDA. Keeps track of everything you copy — text, files, links, and emails — with instant event-driven clipboard monitoring. Browse, search, filter by group, pin important entries, reorder, multi-select and paste in selection order, create new clips with a built-in editor, edit existing entries, select all with Ctrl+A, append text to clipboard, save entries to text or Word files, and paste files back as actual files (CF_HDROP format).",
+	"sha256": "a264c48e26ffdc253da2d4005850332dfa981b2f4aa6c09a0339037fa7b79242",
+	"addonVersionName": "2.0.0",
+	"addonVersionNumber": {
+		"major": 2,
+		"minor": 0,
+		"patch": 0
+	},
+	"minNVDAVersion": {
+		"major": 2024,
+		"minor": 1,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2025,
+		"minor": 3,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "Ahmed Farid",
+	"sourceURL": "https://github.com/ahmed-f-elaswar/clipboardHistory",
+	"license": "GPL v2",
+	"homepage": "https://github.com/ahmed-f-elaswar/clipboardHistory",
+	"changelog": "Clip Editor: Create new clips or edit existing entries with a built-in text editor, with unsaved-changes warning.\nSelect All: Ctrl+A in the history dialog selects all entries.\nEdit shortcut: Ctrl+E to edit the selected entry directly.\nEscape to close: All dialogs close with Escape.\nUI improvements: Search field on its own row, group filter at end of button row.\nUpdated documentation in all 4 languages (English, Arabic, French, Spanish).\nUpdate channel set to stable.",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html",
+	"submissionTime": 1779492303025,
+	"translations": [
+		{
+			"language": "ar",
+			"displayName": "مدير سجل الحافظة",
+			"description": "مدير سجل حافظة مستوحى من Ditto لقارئ الشاشة NVDA. يتتبع كل ما تنسخه — نصوص وملفات وروابط وبريد إلكتروني — مع مراقبة فورية للحافظة. تصفح وابحث وفلتر حسب المجموعة وثبت العناصر المهمة وأعد الترتيب وحدد عناصر متعددة والصقها بترتيب التحديد وأنشئ قصاصات جديدة بمحرر مدمج وعدل العناصر الموجودة وحدد الكل بـ Ctrl+A وألحق نصاً بالحافظة واحفظ العناصر كملفات نصية أو Word والصق الملفات كملفات فعلية (بتنسيق CF_HDROP).",
+			"changelog": "محرر القصاصات: إنشاء قصاصات جديدة أو تعديل العناصر الموجودة بمحرر نصوص مدمج مع تحذير عند وجود تغييرات غير محفوظة.\nتحديد الكل: Ctrl+A في نافذة السجل يحدد جميع العناصر.\nاختصار التعديل: Ctrl+E لتعديل العنصر المحدد مباشرة.\nالإغلاق بـ Escape: جميع النوافذ تُغلق بمفتاح Escape.\nتحسينات الواجهة: حقل البحث في سطر مستقل وفلتر المجموعة في نهاية صف الأزرار.\nتحديث التوثيق بجميع اللغات الأربع (الإنجليزية والعربية والفرنسية والإسبانية).\nقناة التحديث مضبوطة على stable."
+		},
+		{
+			"language": "es",
+			"displayName": "Gestor de Historial del Portapapeles",
+			"description": "Un gestor de historial del portapapeles inspirado en Ditto para NVDA. Registra todo lo que copias — texto, archivos, enlaces y correos electrónicos — con monitoreo instantáneo del portapapeles. Navega, busca, filtra por grupo, fija entradas importantes, reordena, selecciona múltiples entradas y pégalas en orden de selección, crea nuevos clips con un editor integrado, edita entradas existentes, selecciona todo con Ctrl+A, añade texto al portapapeles, guarda entradas en archivos de texto o Word, y pega archivos como archivos reales (formato CF_HDROP).",
+			"changelog": "Editor de clips: Crea nuevos clips o edita entradas existentes con un editor de texto integrado, con advertencia de cambios sin guardar.\nSeleccionar todo: Ctrl+A en el diálogo del historial selecciona todas las entradas.\nAtajo de edición: Ctrl+E para editar la entrada seleccionada directamente.\nCerrar con Escape: Todos los diálogos se cierran con Escape.\nMejoras de interfaz: Campo de búsqueda en su propia fila, filtro de grupo al final de la fila de botones.\nDocumentación actualizada en los 4 idiomas (inglés, árabe, francés, español).\nCanal de actualización establecido en stable."
+		},
+		{
+			"language": "fr",
+			"displayName": "Gestionnaire d'Historique du Presse-papiers",
+			"description": "Un gestionnaire d'historique du presse-papiers inspiré de Ditto pour NVDA. Garde une trace de tout ce que vous copiez — texte, fichiers, liens et e-mails — avec une surveillance instantanée du presse-papiers. Parcourez, recherchez, filtrez par groupe, épinglez les entrées importantes, réorganisez, sélectionnez plusieurs entrées et collez-les dans l'ordre de sélection, créez de nouveaux clips avec un éditeur intégré, modifiez les entrées existantes, sélectionnez tout avec Ctrl+A, ajoutez du texte au presse-papiers, enregistrez les entrées en fichiers texte ou Word, et collez les fichiers en tant que fichiers réels (format CF_HDROP).",
+			"changelog": "Éditeur de clips : Créez de nouveaux clips ou modifiez les entrées existantes avec un éditeur de texte intégré, avec avertissement des modifications non enregistrées.\nSélectionner tout : Ctrl+A dans le dialogue de l'historique sélectionne toutes les entrées.\nRaccourci d'édition : Ctrl+E pour modifier l'entrée sélectionnée directement.\nFermer avec Échap : Tous les dialogues se ferment avec Échap.\nAméliorations de l'interface : Champ de recherche sur sa propre ligne, filtre de groupe à la fin de la rangée de boutons.\nDocumentation mise à jour dans les 4 langues (anglais, arabe, français, espagnol).\nCanal de mise à jour défini sur stable."
+		}
+	]
+}


### PR DESCRIPTION
Submitting Clipboard History Manager v2.0.0 to the NVDA Add-on Store.
## Add-on details
- **Name**: Clipboard History Manager
- **Author**: Ahmed Farid
- **Version**: 2.0.0
- **Channel**: stable
- **Min NVDA**: 2024.1
- **Last tested**: 2025.3
- **Languages**: English, Arabic, Spanish, French
- **License**: GPL v2
- **Source**: https://github.com/ahmed-f-elaswar/clipboardHistory
## Description
A Ditto-inspired clipboard history manager for NVDA with event-driven clipboard monitoring, search, group filtering, pinning, multi-select paste, clip editor, file paste (CF_HDROP), and save to text/Word.