### PR TITLE
Make VirusTotal scan optional for forks and add testing steps

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -252,22 +252,28 @@ jobs:
             setVirusTotalAnalysisStatus({core}, ["${{ needs.getAddonId.outputs.addonFileName }}"])
       - name: Warn if VT not set up correctly
         if: ${{ failure() && steps.checkVTKey.outcome == 'failure' }}
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ inputs.issueNumber }}
-          body: |
-            VirusTotal is not configured for this repository.
-            Please approve the add-on submission manually or configure an API key.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: pwsh
+        run: |
+          $body = @"
+          VirusTotal is not configured for this repository.
+          Please approve the add-on submission manually or configure an API key.
+          "@
+          gh issue comment "${{ inputs.issueNumber }}" --body $body
       - name: Warn if analysis fails
         if: ${{ failure() && steps.setVirusTotalAnalysisStatus.outcome == 'failure' }}
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ inputs.issueNumber }}
-          body: |
-            VirusTotal has flagged this add-on as malicious.
-            You can open this link and [see the results of the analysis](${{ steps.setVirusTotalAnalysisStatus.outputs.vtScanUrl }}).
-            Please contact the flagged security vendors to get them to review and unflag the false positive.
-            Please ask here or email info@nvaccess.org if you need assistance with this process.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: pwsh
+        run: |
+          $body = @"
+          VirusTotal has flagged this add-on as malicious.
+          You can open this link and [see the results of the analysis](${{ steps.setVirusTotalAnalysisStatus.outputs.vtScanUrl }}).
+          Please contact the flagged security vendors to get them to review and unflag the false positive.
+          Please ask here or email info@nvaccess.org if you need assistance with this process.
+          "@
+          gh issue comment "${{ inputs.issueNumber }}" --body $body
 
   commitScanResults:
     needs: [getAddonId, virusTotal-analysis]

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -225,6 +225,7 @@ jobs:
     outputs:
       vtScanUrl: ${{ steps.setVirusTotalAnalysisStatus.outputs.vtScanUrl }}
       vtResultsJSON: ${{ steps.setVirusTotalAnalysisStatus.outputs.vtResults }}
+      vtKeySet: ${{ steps.checkVTKey.outcome == 'success' }}
     steps:
       - name: Check if VT_API_KEY is set
         id: checkVTKey
@@ -270,7 +271,7 @@ jobs:
 
   commitScanResults:
     needs: [getAddonId, virusTotal-analysis]
-    if: ${{ always() }}
+    if: ${{ always() && needs.virusTotal-analysis.outputs.vtKeySet == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -220,12 +220,18 @@ jobs:
       contents: read
       issues: write
     env:
-      VT_API_KEY: ${{ secrets.VT_API_KEY }}
-      VT_API_LIMIT: ${{ vars.VT_API_LIMIT }}
+      VT_API_KEY: ${{ secrets.VT_API_KEY || '' }}
+      VT_API_LIMIT: ${{ vars.VT_API_LIMIT || '50' }}
     outputs:
       vtScanUrl: ${{ steps.setVirusTotalAnalysisStatus.outputs.vtScanUrl }}
       vtResultsJSON: ${{ steps.setVirusTotalAnalysisStatus.outputs.vtResults }}
     steps:
+      - name: Check if VT_API_KEY is set
+        id: checkVTKey
+        if: ${{ !env.VT_API_KEY }}
+        run: |
+          echo "VT_API_KEY secret is not set. Skipping VirusTotal analysis."
+          exit 1
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -243,8 +249,16 @@ jobs:
           script: |
             const setVirusTotalAnalysisStatus = require('./.github/workflows/virusTotalAnalysis.js')
             setVirusTotalAnalysisStatus({core}, ["${{ needs.getAddonId.outputs.addonFileName }}"])
+      - name: Warn if VT not set up correctly
+        if: ${{ failure() && steps.checkVTKey.outcome == 'failure' }}
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ inputs.issueNumber }}
+          body: |
+            VirusTotal is not configured for this repository.
+            Please approve the add-on submission manually or configure an API key.
       - name: Warn if analysis fails
-        if: failure()
+        if: ${{ failure() && steps.setVirusTotalAnalysisStatus.outcome == 'failure' }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ inputs.issueNumber }}

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -226,6 +226,7 @@ jobs:
       vtScanUrl: ${{ steps.setVirusTotalAnalysisStatus.outputs.vtScanUrl }}
       vtResultsJSON: ${{ steps.setVirusTotalAnalysisStatus.outputs.vtResults }}
       vtKeySet: ${{ env.VT_API_KEY != '' }}
+    steps:
       - name: Check if VT_API_KEY is set
         id: checkVTKey
         if: ${{ !env.VT_API_KEY }}

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -225,8 +225,7 @@ jobs:
     outputs:
       vtScanUrl: ${{ steps.setVirusTotalAnalysisStatus.outputs.vtScanUrl }}
       vtResultsJSON: ${{ steps.setVirusTotalAnalysisStatus.outputs.vtResults }}
-      vtKeySet: ${{ steps.checkVTKey.outcome == 'success' }}
-    steps:
+      vtKeySet: ${{ env.VT_API_KEY != '' }}
       - name: Check if VT_API_KEY is set
         id: checkVTKey
         if: ${{ !env.VT_API_KEY }}

--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -89,12 +89,6 @@ jobs:
         git commit -m "Submit add-on"
         # Force push to the branch, as we may need to be handling a resubmission attempt
         git push -f origin ${{ env.branchName }}
-    - name: Install VirusTotal
-      run: choco install vt-cli
-    - name: Scan add-on with VirusTotal
-      env:
-        VT_API_KEY: ${{ secrets.VT_API_KEY }}
-      run: vt scan file -k $env:VT_API_KEY addon.nvda-addon
   call-workflow:
     needs: check-addon
     permissions:

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1,0 +1,45 @@
+# Testing
+
+To test the submission process from end-to-end, you need to fork the repository and submit sample issues there.
+
+## Setup
+
+1. Create a fork from `nvaccess/addon-datastore` named `nvaccess/test-addon-datastore-[testName]`
+1. Configure the fork
+
+   * Enable GitHub Actions
+      * Allow GitHub Actions to create and approve pull requests
+      * Give GitHub Actions read and write permissions.
+   * Enable GitHub Issues
+      * Add the label `autoSubmissionFromIssue`
+   * Enable GitHub Discussions
+      * Create a Discussion Category called: "Add-on Reviews"
+   * Create the following deploy environments.
+   Ensure they both block on your review.
+      * `securityReview`
+      * `submitterReview`
+   * (Optional) For testing VirusTotal scanning, set the following environment keys:
+      * Secret: `VT_API_KEY`.
+      Generate your own using VirusTotal.
+      If not supplied, add-ons won't be scanned.
+      * Variable: `VT_API_LIMIT`.
+      Change if necessary to scan a larger batch of add-ons to push daily API limits.
+
+1. Add it as a remote to your `addon-datastore` local git copy:
+
+   * `git remote add testRemoteName https://github.com/nvaccess/test-addon-datastore-testName.git`
+
+1. (Force) push the branch to your test repository
+
+   * `git push testRemoteName testBranch:master`
+
+## Testing submissions
+
+Once the repository is set up, you should be able to create sample add-on submissions.
+You can use current pending submissions or past rejected add-ons as examples.
+
+You may need to change your submitter status in `submitters.json` to test the workflow properly.
+
+Pushing to views once an add-on submission has been merged is currently not supported.
+This means the "transform to views" step will always fail.
+In future we can create a throwaway staging branch in the main repo, which can be used for testing this step.


### PR DESCRIPTION
This pull request introduces several improvements to the add-on submission workflow, focusing on better handling of VirusTotal API configuration, improved error messaging, and updated documentation for testing. The main changes ensure that the workflow gracefully handles missing VirusTotal credentials and provides clear feedback to users, while also updating developer documentation and removing unused steps.

Tested in conjunction with #9673 to get the fork working properly


* Added a new section to `docs/dev/testing.md` with detailed instructions for setting up and testing the submission process, including guidance on configuring VirusTotal scanning.
* Added a check for the presence of the `VT_API_KEY` secret in `.github/workflows/checkAndSubmitAddonMetadata.yml`. If the key is missing, the VirusTotal analysis step is skipped, and a warning comment is posted on the issue. This prevents workflow failures due to missing credentials and informs users about the required setup. 
* Set a sensible default for `VT_API_LIMIT`
* Modified the `commitScanResults` job to only run if the VirusTotal API key is set, avoiding unnecessary steps when VirusTotal is not configured.
* Added a workflow step that posts a warning comment if VirusTotal is not set up correctly, and adjusted the failure handling to only warn if the VirusTotal analysis step itself fails.
* Removed the VirusTotal CLI installation and scanning steps from `.github/workflows/sendJsonFile.yml`, as these are performed elsewhere as well in `.github\workflows\virusTotalSubmit.js` called from `virusTotal-analysis`. The removed code doesn't perform the expected API rate limiting.