### PR TITLE
Restore redundant VirusTotal scan

### DIFF
--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -13,6 +13,8 @@ jobs:
     name: Check add-on
     if: github.event.label.name == 'autoSubmissionFromIssue'
     runs-on: windows-latest
+    env:
+        VT_API_KEY: ${{ secrets.VT_API_KEY }}
     steps:
     - name: Checkout repo
       uses: actions/checkout@v6
@@ -94,6 +96,12 @@ jobs:
         git add addons
         git commit -m "Submit add-on"
         git push origin ${{ env.branchName }}
+    - name: Install VirusTotal
+      if: env.VT_API_KEY != ''
+      run: choco install vt-cli
+    - name: Scan add-on with VirusTotal
+      if: env.VT_API_KEY != ''
+      run: vt scan file -k $env:VT_API_KEY addon.nvda-addon
   call-workflow:
     needs: check-addon
     permissions:


### PR DESCRIPTION
Fixup of #9689 

Even though we scan with virus total elsewhere, it seems an early scan fixes an unknown problem with scanning just before fetching the anaylsis