### PR TITLE
Better add-on download handling

### DIFF
--- a/.github/workflows/sendJsonFile.yml
+++ b/.github/workflows/sendJsonFile.yml
@@ -33,22 +33,6 @@ jobs:
         python-version: 3.13
     - name: Create validation errors file
       run: echo "" > validationErrors.md
-    - name: Download add-on
-      id: download-addon
-      env:
-        # transfer user input to env variables
-        # https://blog.gitguardian.com/github-actions-security-cheat-sheet/
-        url: ${{ steps.get-data.outputs.downloadUrl }}
-      # wrap all user input in quotations to prevent RCE e.g. www.example.com/&rm -rf
-      run: curl --location --output addon.nvda-addon "$env:url" 2>> validationErrors.md
-    - name: Add extra message if curl fails to validation errors
-      if: ${{ failure() && steps.download-addon.outcome == 'failure' }}
-      run: echo "Error with downloading add-on from download URL" >> validationErrors.md
-    - name: Upload add-on
-      uses: actions/upload-artifact@v4
-      with:
-        name: addon
-        path: addon.nvda-addon
     - name: Create JSON submission from issue
       env:
         # transfer user input to env variables to escape any code

--- a/.github/workflows/testCode.yml
+++ b/.github/workflows/testCode.yml
@@ -64,20 +64,20 @@ jobs:
       # E2E: test to check the script can be run, no need to actually test the file.
       # The internal checks are covered with unit tests.
       run: |
-        .\runvalidate.bat \
-        --dry-run \
-        tests/testData/addons/fake/13.0.0.json \
+        .\runvalidate.bat ^
+        --dry-run ^
+        tests/testData/addons/fake/13.0.0.json ^
         tests/testData/nvdaAPIVersions.json
     - name: Generate json file
       # E2E: test to check the script can be run
       run: |
-        .\runcreatejson.bat \
-        --dry-run \
-        -f tests/testData/fake.nvda-addon \
-        --dir tests/testOutput/test_runcreatejson \
-        --channel=stable \
-        --publisher=fakepublisher \
-        --sourceUrl=https://github.com/fake/ \
-        --url=https://github.com/fake.nvda-addon \
-        --licName="GPL v2" \
+        .\runcreatejson.bat ^
+        --dry-run ^
+        -f tests/testData/fake.nvda-addon ^
+        --dir tests/testOutput/test_runcreatejson ^
+        --channel=stable ^
+        --publisher=fakepublisher ^
+        --sourceUrl=https://github.com/fake/ ^
+        --url=https://github.com/fake.nvda-addon ^
+        --licName="GPL v2" ^
         --licUrl="https://www.gnu.org/licenses/gpl-2.0.html"

--- a/.github/workflows/testCode.yml
+++ b/.github/workflows/testCode.yml
@@ -5,24 +5,30 @@ on:
     branches: [ master ]
     paths-ignore:
       - addons/**
+      - discussions.json
+      - submitters.json
   pull_request:
     branches: [ master ]
     paths-ignore:
       - addons/**
+      - discussions.json
+      - submitters.json
 
 jobs:
   testAllCode:
+    permissions:
+      contents: read
     runs-on: windows-latest
     strategy:
       matrix:
         python-version: [3.13]
     steps:
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8
     - name: Checkout code
       uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
@@ -34,6 +40,8 @@ jobs:
     - name: Run pyright for transform
       run: uv run --group lint --directory transform pyright --threads --level warning
   testValidationCode:
+    permissions:
+      contents: read
     defaults:
       run:
         shell: cmd
@@ -44,18 +52,32 @@ jobs:
         python-version: [3.13]
     steps:
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8
     - name: Checkout code
       uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
     - name: Validate metadata
       # E2E: test to check the script can be run, no need to actually test the file.
       # The internal checks are covered with unit tests.
-      run: .\runvalidate.bat --dry-run tests/testData/addons/fake/13.0.0.json tests/testData/nvdaAPIVersions.json
+      run: |
+        .\runvalidate.bat \
+        --dry-run \
+        tests/testData/addons/fake/13.0.0.json \
+        tests/testData/nvdaAPIVersions.json
     - name: Generate json file
       # E2E: test to check the script can be run
-      run: .\runcreatejson.bat -f tests/testData/fake.nvda-addon --dir tests/testOutput/test_runcreatejson --channel=stable --publisher=fakepublisher --sourceUrl=https://github.com/fake/ --url=https://github.com/fake.nvda-addon --licName="GPL v2" --licUrl="https://www.gnu.org/licenses/gpl-2.0.html"
+      run: |
+        .\runcreatejson.bat \
+        --dry-run \
+        -f tests/testData/fake.nvda-addon \
+        --dir tests/testOutput/test_runcreatejson \
+        --channel=stable \
+        --publisher=fakepublisher \
+        --sourceUrl=https://github.com/fake/ \
+        --url=https://github.com/fake.nvda-addon \
+        --licName="GPL v2" \
+        --licUrl="https://www.gnu.org/licenses/gpl-2.0.html"

--- a/.github/workflows/testCode.yml
+++ b/.github/workflows/testCode.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: [3.13]
     steps:
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.2.0
     - name: Checkout code
       uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
@@ -52,7 +52,7 @@ jobs:
         python-version: [3.13]
     steps:
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.2.0
     - name: Checkout code
       uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}

--- a/validation/_validate/createJson.py
+++ b/validation/_validate/createJson.py
@@ -228,7 +228,7 @@ def main():
 	errors = list(downloadAndValidateAddon(args.url, args.file))
 	if errors:
 		outputErrors(args.file, errors, errorFilePath)
-		raise ValueError(f"Unable to download and validate the add-on.")
+		raise ValueError("Unable to download and validate the add-on.")
 
 	try:
 		manifest = getAddonManifest(args.file)

--- a/validation/_validate/createJson.py
+++ b/validation/_validate/createJson.py
@@ -222,13 +222,22 @@ def main():
 		default=None,
 		required=False,
 	)
+	parser.add_argument(
+		"--dry-run",
+		dest="dryRun",
+		help="Whether to run the script without actually downloading the addon, instead using a local file.",
+		action="store_true",
+		default=False,
+		required=False,
+	)
 	args = parser.parse_args()
 	errorFilePath: str | None = args.errorOutputFile
 
-	errors = list(downloadAndValidateAddon(args.url, args.file))
-	if errors:
-		outputErrors(args.file, errors, errorFilePath)
-		raise ValueError("Unable to download and validate the add-on.")
+	if not args.dryRun:
+		errors = list(downloadAndValidateAddon(args.url, args.file))
+		if errors:
+			outputErrors(args.file, errors, errorFilePath)
+			raise ValueError("Unable to download and validate the add-on.")
 
 	try:
 		manifest = getAddonManifest(args.file)

--- a/validation/_validate/createJson.py
+++ b/validation/_validate/createJson.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2025 Noelia Ruiz Martínez, NV Access Limited
+# Copyright (C) 2022-2026 Noelia Ruiz Martínez, NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,7 +14,7 @@ from .addonManifest import AddonManifest, ApiVersionT
 from .manifestLoader import getAddonManifest, getAddonManifestLocalizations
 from .majorMinorPatch import MajorMinorPatch
 from .sha256 import sha256_checksum
-from .validate import parseConfigValue
+from .validate import downloadAndValidateAddon, outputErrors, parseConfigValue
 
 
 @dataclasses.dataclass
@@ -170,7 +170,7 @@ def main():
 	parser.add_argument(
 		"-f",
 		dest="file",
-		help="The add-on (nvda-addon) file to create json from manifest.",
+		help="The add-on (nvda-addon) file to download to.",
 		required=True,
 	)
 	parser.add_argument(
@@ -224,6 +224,11 @@ def main():
 	)
 	args = parser.parse_args()
 	errorFilePath: str | None = args.errorOutputFile
+
+	errors = list(downloadAndValidateAddon(args.url, args.file))
+	if errors:
+		outputErrors(args.file, errors, errorFilePath)
+		raise ValueError(f"Unable to download and validate the add-on.")
 
 	try:
 		manifest = getAddonManifest(args.file)

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -84,7 +84,11 @@ def downloadAddon(url: str, destPath: str) -> ValidationErrorGenerator:
 	Raise on failure.
 	"""
 	DOWNLOAD_BLOCK_SIZE = 8192  # 8 kb
-	remote = urllib.request.urlopen(url)
+	try:
+		remote = urllib.request.urlopen(url)
+	except Exception as e:
+		yield f"Unable to download from {url}, error: {e}"
+		raise RuntimeError(f"Unable to download from {url}, error: {e}") from e
 	if remote.code != 200:
 		yield "Download of addon failed"
 		raise RuntimeError(f"Unable to download from {url}, HTTP response status code: {remote.code}")

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -81,17 +81,15 @@ def checkDownloadUrlFormat(url: str) -> ValidationErrorGenerator:
 
 def downloadAddon(url: str, destPath: str) -> ValidationErrorGenerator:
 	"""Download the addon file, save as destPath
-	Raise on failure.
 	"""
 	DOWNLOAD_BLOCK_SIZE = 8192  # 8 kb
 	try:
 		remote = urllib.request.urlopen(url)
 	except Exception as e:
 		yield f"Unable to download from {url}, error: {e}"
-		raise RuntimeError(f"Unable to download from {url}, error: {e}") from e
+		return
 	if remote.code != 200:
-		yield "Download of addon failed"
-		raise RuntimeError(f"Unable to download from {url}, HTTP response status code: {remote.code}")
+		yield f"Unable to download from {url}, HTTP response status code: {remote.code}"
 	size = int(remote.headers["content-length"])
 	with open(destPath, "wb") as local:
 		read = 0

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -354,6 +354,7 @@ def validateSubmission(submissionFilePath: str, verFilename: str) -> ValidationE
 		addonDestPath = os.path.join(TEMP_DIR, "addon.nvda-addon")
 		if os.path.exists(addonDestPath):
 			os.remove(addonDestPath)
+
 		downloadErrors = downloadAndValidateAddon(
 			url=submissionData["URL"],
 			addonDestPath=addonDestPath,

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -360,7 +360,9 @@ def validateSubmission(submissionFilePath: str, verFilename: str) -> ValidationE
 			addonDestPath=addonDestPath,
 		)
 		if downloadErrors:
-			raise ValueError(f"Errors found when downloading and validating the add-on: {', '.join(downloadErrors)}")
+			raise ValueError(
+				f"Errors found when downloading and validating the add-on: {', '.join(downloadErrors)}"
+			)
 
 		checksumErrors = list(checkSha256(addonDestPath, expectedSha=submissionData["sha256"]))
 		if checksumErrors:

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -90,6 +90,7 @@ def downloadAddon(url: str, destPath: str) -> ValidationErrorGenerator:
 		return
 	if remote.code != 200:
 		yield f"Unable to download from {url}, HTTP response status code: {remote.code}"
+		return
 	size = int(remote.headers["content-length"])
 	with open(destPath, "wb") as local:
 		read = 0

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -329,9 +329,7 @@ def downloadAndValidateAddon(
 	url: str,
 	addonDestPath: str,
 ) -> ValidationErrorGenerator:
-	"""Download the addon and validate the url.
-	Raise on failure.
-	"""
+	"""Download the add-on and validate the url."""
 	urlErrors = list(checkDownloadUrlFormat(url))
 	if urlErrors:
 		yield from urlErrors

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -355,10 +355,10 @@ def validateSubmission(submissionFilePath: str, verFilename: str) -> ValidationE
 		if os.path.exists(addonDestPath):
 			os.remove(addonDestPath)
 
-		downloadErrors = downloadAndValidateAddon(
+		downloadErrors = list(downloadAndValidateAddon(
 			url=submissionData["URL"],
 			addonDestPath=addonDestPath,
-		)
+		))
 		if downloadErrors:
 			# if there are errors in the download, the validation can not continue
 			raise ValueError(

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -80,8 +80,7 @@ def checkDownloadUrlFormat(url: str) -> ValidationErrorGenerator:
 
 
 def downloadAddon(url: str, destPath: str) -> ValidationErrorGenerator:
-	"""Download the addon file, save as destPath
-	"""
+	"""Download the addon file, save as destPath"""
 	DOWNLOAD_BLOCK_SIZE = 8192  # 8 kb
 	try:
 		remote = urllib.request.urlopen(url)

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -355,10 +355,12 @@ def validateSubmission(submissionFilePath: str, verFilename: str) -> ValidationE
 		if os.path.exists(addonDestPath):
 			os.remove(addonDestPath)
 
-		downloadErrors = list(downloadAndValidateAddon(
-			url=submissionData["URL"],
-			addonDestPath=addonDestPath,
-		))
+		downloadErrors = list(
+			downloadAndValidateAddon(
+				url=submissionData["URL"],
+				addonDestPath=addonDestPath,
+			),
+		)
 		if downloadErrors:
 			# if there are errors in the download, the validation can not continue
 			raise ValueError(

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2025 Noelia Ruiz Martínez, NV Access Limited
+# Copyright (C) 2021-2026 Noelia Ruiz Martínez, NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -323,6 +323,23 @@ def checkVersions(
 	yield from checkParsedVersionNameMatchesVersionNumber(submission)
 
 
+def downloadAndValidateAddon(
+	url: str,
+	addonDestPath: str,
+) -> ValidationErrorGenerator:
+	"""Download the addon and validate the url.
+	Raise on failure.
+	"""
+	urlErrors = list(checkDownloadUrlFormat(url))
+	if urlErrors:
+		# if there are errors in the URL validation can not continue
+		yield from urlErrors
+
+	if os.path.exists(addonDestPath):
+		os.remove(addonDestPath)
+	yield from downloadAddon(url=url, destPath=addonDestPath)
+
+
 def validateSubmission(submissionFilePath: str, verFilename: str) -> ValidationErrorGenerator:
 	try:
 		submissionData = getAddonMetadata(filename=submissionFilePath)
@@ -331,16 +348,15 @@ def validateSubmission(submissionFilePath: str, verFilename: str) -> ValidationE
 			# Legacy add-ons do not need a valid manifest or metadata
 			return None
 
-		urlErrors = list(checkDownloadUrlFormat(submissionData["URL"]))
-		if urlErrors:
-			# if there are errors in the URL validation can not continue
-			yield from urlErrors
-			raise ValueError(submissionData["URL"])
-
 		addonDestPath = os.path.join(TEMP_DIR, "addon.nvda-addon")
 		if os.path.exists(addonDestPath):
 			os.remove(addonDestPath)
-		yield from downloadAddon(url=submissionData["URL"], destPath=addonDestPath)
+		downloadErrors = downloadAndValidateAddon(
+			url=submissionData["URL"],
+			addonDestPath=addonDestPath,
+		)
+		if downloadErrors:
+			raise ValueError(f"Errors found when downloading and validating the add-on: {', '.join(downloadErrors)}")
 
 		checksumErrors = list(checkSha256(addonDestPath, expectedSha=submissionData["sha256"]))
 		if checksumErrors:

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -361,7 +361,7 @@ def validateSubmission(submissionFilePath: str, verFilename: str) -> ValidationE
 		)
 		if downloadErrors:
 			raise ValueError(
-				f"Errors found when downloading and validating the add-on: {', '.join(downloadErrors)}"
+				f"Errors found when downloading and validating the add-on: {', '.join(downloadErrors)}",
 			)
 
 		checksumErrors = list(checkSha256(addonDestPath, expectedSha=submissionData["sha256"]))

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -336,8 +336,9 @@ def downloadAndValidateAddon(
 	"""
 	urlErrors = list(checkDownloadUrlFormat(url))
 	if urlErrors:
-		# if there are errors in the URL validation can not continue
 		yield from urlErrors
+		# if there are errors in the URL validation the download can not continue
+		return
 
 	if os.path.exists(addonDestPath):
 		os.remove(addonDestPath)
@@ -360,6 +361,7 @@ def validateSubmission(submissionFilePath: str, verFilename: str) -> ValidationE
 			addonDestPath=addonDestPath,
 		)
 		if downloadErrors:
+			# if there are errors in the download, the validation can not continue
 			raise ValueError(f"Errors found when downloading and validating the add-on: {', '.join(downloadErrors)}")
 
 		checksumErrors = list(checkSha256(addonDestPath, expectedSha=submissionData["sha256"]))

--- a/validation/tests/test_createJson.py
+++ b/validation/tests/test_createJson.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2025 Noelia Ruiz Martínez, NV Access Limited
+# Copyright (C) 2022-2026 Noelia Ruiz Martínez, NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -6,6 +6,7 @@ import unittest
 import os
 import shutil
 import json
+from unittest.mock import NonCallableMock, patch
 from _validate import createJson, addonManifest, manifestLoader
 
 TOP_DIR = os.path.abspath(os.path.dirname(__file__))
@@ -130,3 +131,53 @@ class Test_normalizeLanguage(unittest.TestCase):
 		Also implicitly test the fact that country code is converted to upper case."""
 		self.assertEqual("pt_BR", manifestLoader.normalizeLanguage("pt_BR"))
 		self.assertEqual("pt_BR", manifestLoader.normalizeLanguage("pt-BR"))
+
+
+class Test_main(unittest.TestCase):
+	def _buildArgv(self, licenseUrl: str | None = None) -> list[str]:
+		args = [
+			"createJson.py",
+			"-f",
+			ADDON_PACKAGE,
+			"--dir",
+			OUTPUT_DATA_PATH,
+			"--channel",
+			ADDON_CHANNEL,
+			"--publisher",
+			ADDON_PUBLISHER,
+			"--sourceUrl",
+			ADDON_SOURCE_URL,
+			"--url",
+			"https://example.com/fake.nvda-addon",
+			"--licName",
+			"GPL v2",
+		]
+		if licenseUrl is not None:
+			args.extend(["--licUrl", licenseUrl])
+		return args
+
+	def test_downloadValidationFailure(self):
+		with (
+			patch("sys.argv", self._buildArgv()),
+			patch("_validate.createJson.downloadAndValidateAddon", return_value=["download error"]),
+			patch("_validate.createJson.outputErrors") as mock_outputErrors,
+			patch("_validate.createJson.getAddonManifest") as mock_getManifest,
+		):
+			with self.assertRaisesRegex(ValueError, "Unable to download and validate the add-on"):
+				createJson.main()
+
+		mock_outputErrors.assert_called_once_with(ADDON_PACKAGE, ["download error"], None)
+		mock_getManifest.assert_not_called()
+
+	def test_licUrlEmptyStringBecomesNone(self):
+		manifest = NonCallableMock(errors=[])
+		with (
+			patch("sys.argv", self._buildArgv(licenseUrl="")),
+			patch("_validate.createJson.downloadAndValidateAddon", return_value=[]),
+			patch("_validate.createJson.getAddonManifest", return_value=manifest),
+			patch("_validate.createJson.generateJsonFile") as mock_generateJsonFile,
+		):
+			createJson.main()
+
+		mock_generateJsonFile.assert_called_once()
+		self.assertIsNone(mock_generateJsonFile.call_args.kwargs["licenseUrl"])

--- a/validation/tests/test_validate.py
+++ b/validation/tests/test_validate.py
@@ -123,7 +123,7 @@ class Validate_downloadAndValidateAddon(unittest.TestCase):
 		with patch(
 			"_validate.validate.downloadAddon",
 			return_value=[
-				"Unable to download from https://example.com/fake.nvda-addon, HTTP response status code: 404"
+				"Unable to download from https://example.com/fake.nvda-addon, HTTP response status code: 404",
 			],
 		):
 			errors = list(

--- a/validation/tests/test_validate.py
+++ b/validation/tests/test_validate.py
@@ -107,7 +107,7 @@ class Validate_downloadAndValidateAddon(unittest.TestCase):
 			with open(destPath, "wb") as f:
 				f.write(b"old-data")
 
-			with patch("_validate.validate.downloadAddon", return_value=[] ) as mock_download:
+			with patch("_validate.validate.downloadAddon", return_value=[]) as mock_download:
 				errors = list(
 					validate.downloadAndValidateAddon(
 						"https://example.com/fake.nvda-addon",
@@ -122,7 +122,9 @@ class Validate_downloadAndValidateAddon(unittest.TestCase):
 	def test_downloadErrorsPropagated(self):
 		with patch(
 			"_validate.validate.downloadAddon",
-			return_value=["Unable to download from https://example.com/fake.nvda-addon, HTTP response status code: 404"],
+			return_value=[
+				"Unable to download from https://example.com/fake.nvda-addon, HTTP response status code: 404"
+			],
 		):
 			errors = list(
 				validate.downloadAndValidateAddon(

--- a/validation/tests/test_validate.py
+++ b/validation/tests/test_validate.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2025 Noelia Ruiz Martínez, NV Access Limited
+# Copyright (C) 2021-2026 Noelia Ruiz Martínez, NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -8,6 +8,7 @@ import unittest
 from unittest.mock import NonCallableMock, patch
 import os
 import json
+import tempfile
 from jsonschema import exceptions
 from _validate import validate, addonManifest
 
@@ -82,6 +83,58 @@ class Validate_checkDownloadUrlFormat(unittest.TestCase):
 			[
 				"Add-on download url must start with https://",
 				"Add-on download url must end with .nvda-addon",
+			],
+		)
+
+
+class Validate_downloadAndValidateAddon(unittest.TestCase):
+	def test_invalidUrlStopsBeforeDownload(self):
+		with patch("_validate.validate.downloadAddon") as mock_download:
+			errors = list(validate.downloadAndValidateAddon("http://example.com", "dest.nvda-addon"))
+
+		self.assertEqual(
+			errors,
+			[
+				"Add-on download url must start with https://",
+				"Add-on download url must end with .nvda-addon",
+			],
+		)
+		mock_download.assert_not_called()
+
+	def test_existingDestinationFileRemovedBeforeDownload(self):
+		with tempfile.TemporaryDirectory() as tempDir:
+			destPath = os.path.join(tempDir, "addon.nvda-addon")
+			with open(destPath, "wb") as f:
+				f.write(b"old-data")
+
+			with patch("_validate.validate.downloadAddon", return_value=[] ) as mock_download:
+				errors = list(
+					validate.downloadAndValidateAddon(
+						"https://example.com/fake.nvda-addon",
+						destPath,
+					),
+				)
+
+		self.assertEqual(errors, [])
+		self.assertFalse(os.path.exists(destPath))
+		mock_download.assert_called_once_with(url="https://example.com/fake.nvda-addon", destPath=destPath)
+
+	def test_downloadErrorsPropagated(self):
+		with patch(
+			"_validate.validate.downloadAddon",
+			return_value=["Unable to download from https://example.com/fake.nvda-addon, HTTP response status code: 404"],
+		):
+			errors = list(
+				validate.downloadAndValidateAddon(
+					"https://example.com/fake.nvda-addon",
+					"addon.nvda-addon",
+				),
+			)
+
+		self.assertEqual(
+			errors,
+			[
+				"Unable to download from https://example.com/fake.nvda-addon, HTTP response status code: 404",
 			],
 		)
 
@@ -715,12 +768,9 @@ class Validate_End2End(unittest.TestCase):
 		self.assertEqual(
 			errors,
 			[
-				"Download of addon failed",
-				"Fatal error, unable to continue: Unable to download from "
-				# note this the mocked urlopen function actually fetches from ADDON_PACKAGE
-				"https://github.com/"
-				"nvaccess/dont/use/this/address/fake.nvda-addon, "
-				"HTTP response status code: 404",
+				"Fatal error, unable to continue: Errors found when downloading and validating "
+				"the add-on: Unable to download from https://github.com/nvaccess/dont/use/this/address/"
+				"fake.nvda-addon, HTTP response status code: 404",
 			],
 		)
 


### PR DESCRIPTION
Fixes #3253

The code to initially download the add-on has bad error handling.
That means for bad URLs / 404s, no good communication to the submitter happens.
Recent example: #9821
We can fix this by using our reusable validation code to download the add-on with instead.

However, when using it, if a 404 is raised from `urlopen` it causes an exception, which when logged doesn't provide a clear error message. This caused #3253.

Unit tests have been added (AI gen) and system tests have been updated.

---

* The add-on download and error handling steps were removed from the `.github/workflows/sendJsonFile.yml` workflow, centralizing this logic in the Python validation code instead. (`.github/workflows/sendJsonFile.yml` [.github/workflows/sendJsonFile.ymlL36-L51](diffhunk://#diff-676fb38bd015d01c4ceaf27dce3840b653fb8a8f220b07e24707145552fd55eeL36-L51))
* The `downloadAndValidateAddon` function was added to `validate.py` to handle both URL validation and downloading the add-on, yielding errors and raising exceptions as needed. (`validation/_validate/validate.py` [validation/_validate/validate.pyR330-R346](diffhunk://#diff-f55855b4d09afe004e9f56b353f0eaa774d0e896a0dc8dbe50466ae61a668fcaR330-R346))
* The main function in `createJson.py` now calls `downloadAndValidateAddon` and outputs errors if the download or validation fails, improving error handling and reporting. (`validation/_validate/createJson.py` [validation/_validate/createJson.pyR228-R232](diffhunk://#diff-0f126f4d1ded77abdfb6ebb806debcfb7fc0720dcdb4cb0513d743ceeff0146cR228-R232))
* The `validateSubmission` function was updated to use `downloadAndValidateAddon`, simplifying the code and ensuring consistent validation logic. (`validation/_validate/validate.py` [validation/_validate/validate.pyL334-R363](diffhunk://#diff-f55855b4d09afe004e9f56b353f0eaa774d0e896a0dc8dbe50466ae61a668fcaL334-R363))
* Improved error handling in `downloadAddon` to yield and raise exceptions with descriptive messages on failure. (`validation/_validate/validate.py` [validation/_validate/validate.pyR87-R91](diffhunk://#diff-f55855b4d09afe004e9f56b353f0eaa774d0e896a0dc8dbe50466ae61a668fcaR87-R91))