### PR TITLE
Prevent merge conflicts with concurrency

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -316,7 +316,7 @@ jobs:
       - name: Confirm manual review passed
         run: echo "Passed manual review"
 
-  pushFurtherChanges:
+  pushFurtherChangesAndMerge:
     concurrency:
       # When modifying submitters.json or discussions.json,
       # we want to avoid merge conflicts by ensuring only one workflow can push changes at a time.
@@ -326,10 +326,11 @@ jobs:
     # use linux instead.
     runs-on: ubuntu-latest
     if: ${{ always() && needs.passesManualReview.result == 'success' }}
-    needs: [getAddonId, passesManualReview, requireSubmitterManualApproval, virusTotal-analysis]
+    needs: [getAddonId, passesManualReview, createPullRequest, requireSubmitterManualApproval, virusTotal-analysis]
     permissions:
       contents: write
       discussions: write
+      pull-requests: write
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -411,8 +412,7 @@ jobs:
         jqExitCode=$?
         rm discussions.old.json
         exit $jqExitCode
-    - name: Add discussion and VT scan URL to metadata
-      if: always()
+    - name: Add discussion URL to metadata
       run: |
         addonFilename=$(
           echo "${{ needs.getAddonId.outputs.addonFileName }}"
@@ -423,26 +423,15 @@ jobs:
         reviewUrl=$(
           jq --tab ".\"$addonId\".discussionUrl" discussions.json
         )
-        vtScanUrl=$(
-          echo ${{ needs.virusTotal-analysis.outputs.vtScanUrl }}
-        )
         jqReviewCode="
-        .[\"reviewUrl\"] = $reviewUrl
-        "
-        jqVTCode="
         .[\"reviewUrl\"] = $reviewUrl
         "
 
         mv $addonFilename $addonFilename.old.json
         jq -e --tab "$jqReviewCode" $addonFilename.old.json > $addonFilename
         jqReviewExitCode=$?
-        mv $addonFilename $addonFilename.old.json
-        jq -e --tab "$jqVTCode" $addonFilename.old.json > $addonFilename
-        jqVTExitCode=$?
         rm $addonFilename.old.json
-        exit $(( $jqVTExitCode || $jqReviewExitCode ))
     - name: Commit and push
-      if: always()
       run: |
         git add .
         if git diff --staged --quiet; then
@@ -452,34 +441,18 @@ jobs:
           git pull --rebase origin ${{ env.branchName }}
           git push --set-upstream origin ${{ env.branchName }}
         fi
-
-  mergeToMaster:
-    concurrency:
-      # When modifying submitters.json or discussions.json,
-      # we want to avoid merge conflicts by ensuring only one workflow can push changes at a time.
-      group: avoidMergeConflicts
-      queue: max
-    needs: [getAddonId, pushFurtherChanges, createPullRequest, passesManualReview]
-    if: ${{ always() && needs.pushFurtherChanges.result == 'success' && needs.passesManualReview.result == 'success' }}
-    permissions:
-      contents: write
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Merge branch to master
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh pr merge --squash ${{ env.branchName }} -b '[Automated] Merged ${{ needs.getAddonId.outputs.addonFileName }} into master (PR #${{ needs.createPullRequest.outputs.pullRequestNumber }})'
+    - name: Merge branch to master
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh pr merge --squash ${{ env.branchName }} -b '[Automated] Merged ${{ needs.getAddonId.outputs.addonFileName }} into master (PR #${{ needs.createPullRequest.outputs.pullRequestNumber }})'
 
   call-workflow:
-    needs: [mergeToMaster]
+    needs: [pushFurtherChangesAndMerge]
     permissions:
       contents: write
       pull-requests: write
-    if: ${{ always() && needs.mergeToMaster.result == 'success' }}
+    if: ${{ always() && needs.pushFurtherChangesAndMerge.result == 'success' }}
     uses: ./.github/workflows/transformDataToViews.yml
     secrets:
       VIEWS_PUSH_TOKEN: ${{ secrets.VIEWS_PUSH_TOKEN }}

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -325,7 +325,7 @@ jobs:
     # jq for windows has issues parsing multiline strings (e.g. CRLF),
     # use linux instead.
     runs-on: ubuntu-latest
-    if: ${{ always() && needs.passesManualReview.result == 'success' }}
+    if: ${{ always() && needs.passesManualReview.result == 'success' && needs.getAddonId.result == 'success' && needs.createPullRequest.result == 'success' }}
     needs: [getAddonId, passesManualReview, createPullRequest, requireSubmitterManualApproval, virusTotal-analysis]
     permissions:
       contents: write

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -395,6 +395,7 @@ jobs:
       contents: write
       discussions: write
       pull-requests: write
+      issues: write
     steps:
     - name: Checkout code
       uses: actions/checkout@v6

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -24,9 +24,6 @@ env:
 jobs:
   getAddonId:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: [ 3.13 ]
     permissions:
       contents: write
       issues: write
@@ -91,9 +88,6 @@ jobs:
     # use linux instead.
     runs-on: ubuntu-latest
     needs: [getAddonId]
-    strategy:
-      matrix:
-        python-version: [ 3.13 ]
     permissions:
       contents: write
       pull-requests: write
@@ -137,9 +131,6 @@ jobs:
   createPullRequest:
     runs-on: windows-latest
     needs: [getAddonId]
-    strategy:
-      matrix:
-        python-version: [ 3.13 ]
     permissions:
       contents: write
       pull-requests: write
@@ -192,9 +183,6 @@ jobs:
   virusTotal-analysis:
     needs: [getAddonId, createPullRequest]
     runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: [ 3.13 ]
     permissions:
       contents: read
       issues: write
@@ -310,45 +298,15 @@ jobs:
         run: echo "Manual approval performed"
 
   requireSubmitterManualApproval:
-    needs: [getAddonId, verifySubmitter]
+    needs: [verifySubmitter]
     if: ${{ always() && (needs.verifySubmitter.result == 'failure') }}
     runs-on: ubuntu-latest
     environment:
       # Require a manual deployment approval if manual approval is required for the submitter
       name: submitterReview
-    permissions:
-      contents: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ env.branchName }}
-          # Get deeper history to ensure merge with master can happen
-          fetch-depth: 0
-      - name: Update branch to avoid conflicts
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git pull --rebase origin ${{ env.branchName }}
-          git fetch origin master
-          git merge origin/master --no-edit
-      - name: Add add-on ID and submitter to JSON file
-        run: |
-          jqCode="
-          .[\"${{ inputs.issueAuthorId }}\"].addons += [\"${{ needs.getAddonId.outputs.addonId }}\"]
-          | .[\"${{ inputs.issueAuthorId }}\"].githubName = \"${{ inputs.issueAuthorName }}\"
-          "
-
-          mv submitters.json submitters.old.json
-          jq -e --tab "$jqCode" submitters.old.json > submitters.json
-          jqExitCode=$?
-          rm submitters.old.json
-          exit $jqExitCode
-      - name: Commit submitters.json changes
-        run: |
-          git add submitters.json
-          git commit -m "Add ${{ inputs.issueAuthorName }} as an approved submitter for ${{ needs.getAddonId.outputs.addonId }}"
-          git push --set-upstream origin ${{ env.branchName }}
+      - name: Confirm approval
+        run: echo "Manual approval performed"
 
   passesManualReview:
     needs: [requireSecurityManualApproval, requireSubmitterManualApproval, commitScanResults]
@@ -358,15 +316,17 @@ jobs:
       - name: Confirm manual review passed
         run: echo "Passed manual review"
 
-  createReviewComment:
+  pushFurtherChanges:
+    concurrency:
+      # When modifying submitters.json or discussions.json,
+      # we want to avoid merge conflicts by ensuring only one workflow can push changes at a time.
+      group: avoidMergeConflicts
+      queue: max
     # jq for windows has issues parsing multiline strings (e.g. CRLF),
     # use linux instead.
     runs-on: ubuntu-latest
     if: ${{ always() && needs.passesManualReview.result == 'success' }}
-    needs: [getAddonId, passesManualReview, virusTotal-analysis]
-    strategy:
-      matrix:
-        python-version: [ 3.13 ]
+    needs: [getAddonId, passesManualReview, requireSubmitterManualApproval, virusTotal-analysis]
     permissions:
       contents: write
       discussions: write
@@ -392,6 +352,25 @@ jobs:
           const setAddonNameAndVersion = require('./.github/workflows/getAddonNameAndVersion.js')
           const addonFilename = "${{ needs.getAddonId.outputs.addonFileName }}"
           setAddonNameAndVersion({core}, addonFilename)
+    - name: Add add-on ID and submitter to JSON file
+      if: ${{ needs.requireSubmitterManualApproval.result == 'success' }}
+      run: |
+        jqCode="
+        .[\"${{ inputs.issueAuthorId }}\"].addons += [\"${{ needs.getAddonId.outputs.addonId }}\"]
+        | .[\"${{ inputs.issueAuthorId }}\"].githubName = \"${{ inputs.issueAuthorName }}\"
+        "
+
+        mv submitters.json submitters.old.json
+        jq -e --tab "$jqCode" submitters.old.json > submitters.json
+        jqExitCode=$?
+        rm submitters.old.json
+        exit $jqExitCode
+    - name: Commit submitters.json changes
+      if: ${{ needs.requireSubmitterManualApproval.result == 'success' }}
+      run: |
+        git add submitters.json
+        git commit -m "Add ${{ inputs.issueAuthorName }} as an approved submitter for ${{ needs.getAddonId.outputs.addonId }}"
+        git push --set-upstream origin ${{ env.branchName }}
     - name: Check if discussion for this add-on exists
       id: checkDiscussion
       run: |
@@ -475,15 +454,17 @@ jobs:
         fi
 
   mergeToMaster:
-    needs: [getAddonId, createReviewComment, createPullRequest, passesManualReview]
-    if: ${{ always() && needs.createReviewComment.result == 'success' && needs.passesManualReview.result == 'success' }}
+    concurrency:
+      # When modifying submitters.json or discussions.json,
+      # we want to avoid merge conflicts by ensuring only one workflow can push changes at a time.
+      group: avoidMergeConflicts
+      queue: max
+    needs: [getAddonId, pushFurtherChanges, createPullRequest, passesManualReview]
+    if: ${{ always() && needs.pushFurtherChanges.result == 'success' && needs.passesManualReview.result == 'success' }}
     permissions:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ 3.13 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -431,6 +431,7 @@ jobs:
         jq -e --tab "$jqReviewCode" $addonFilename.old.json > $addonFilename
         jqReviewExitCode=$?
         rm $addonFilename.old.json
+        exit $jqReviewExitCode
     - name: Commit and push
       run: |
         git add .

--- a/.github/workflows/regenerateJson.yml
+++ b/.github/workflows/regenerateJson.yml
@@ -9,9 +9,6 @@ jobs:
       contents: write
       pull-requests: write
     runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: [ 3.13 ]
     steps:
     - name: Checkout code
       uses: actions/checkout@v6

--- a/.github/workflows/validateAllAddons.yml
+++ b/.github/workflows/validateAllAddons.yml
@@ -12,9 +12,6 @@ jobs:
       contents: write
       pull-requests: write
     runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: [ 3.13 ]
     steps:
     - name: Checkout code
       uses: actions/checkout@v6

--- a/docs/dev/submissionReview.md
+++ b/docs/dev/submissionReview.md
@@ -33,11 +33,8 @@ The process for reviewing pending first submissions is as follows:
    * Check for any obvious red flags with the repository i.e. it doesn't look structured as an add-on, inappropriate content in the readme, author and code only been around for a few days
    * Ensure there is not a clash of add-on IDs by checking [submitters.json](../../submitters.json) for similar IDs.
 1. Approve or deny the `submitterReview` deploy environment.
-If the deployment review request has expired, close the PR and re-run the job.
-1. When rejecting, close the associated PR and issue manually, and provide feedback to the author on the issue.
-1. If the "merge to master" step fails due to merge conflicts in `submitters.json` or `discussions.json`, resolve them manually and merge.
-To avoid conflicts, wait until an add-on completes the "merge to master" step before approving the next add-on.
-This means waiting 2-5min between approvals.
+    * If the deployment review request has expired, close the PR and re-run the job.
+    * When rejecting, close the associated PR and issue manually, and provide feedback to the author on the issue.
 
 ## Approving an add-on which was flagged as malicious
 
@@ -45,10 +42,10 @@ An add-on may be flagged as malicious by VirusTotal.
 
 ### Process for flagged add-ons
 
+1. Open the referenced issue and related PR.
 1. A comment should appear on the GitHub issue with information on why the add-on was flagged.
 1. Consider if the flagged content is a false positive.
 This may require discussion within NV Access or with the add-on contributor.
-1. Go to the failed submission in GitHub Actions.
-Approve or deny the `securityReview` deployment.
-If the deployment review request has expired, close the PR and re-run the job.
-1. When rejecting, close the associated PR and issue manually, and provide feedback to the author on the issue.
+1. Approve or deny the `securityReview` deployment.
+    * If the deployment review request has expired, close the PR and re-run the job.
+    * When rejecting, close the associated PR and issue manually, and provide feedback to the author on the issue.


### PR DESCRIPTION
Fixes #9775 

When multiple submissions are between the steps of:

-  modifying discussions.json or submitters.json
-  merging the add-on submission to master

merge conflicts can occur.
This is avoided by preventing concurrency during these steps, and queuing using queue: max  in the [concurrency group for the steps](https://docs.github.com/en/enterprise-cloud@latest/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)

Also:

- removes redundant vtScanUrl being added - also removed code is buggy/incorrect
- merges a few existing jobs into one job to ensure lock is held while modifying files and merging to master