### PR TITLE
Add nvdaMacroManager v1.2.3

### DIFF
--- a/addons/nvdaMacroManager/1.2.3.json
+++ b/addons/nvdaMacroManager/1.2.3.json
@@ -25,5 +25,6 @@
 	"sourceURL": "https://github.com/m-enes-senovali/nvdaMacroManager",
 	"license": "GPL v2",
 	"homepage": "https://github.com/m-enes-senovali/nvdaMacroManager",
-	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html",
+	"translations": []
 }

--- a/addons/nvdaMacroManager/1.2.3.json
+++ b/addons/nvdaMacroManager/1.2.3.json
@@ -1,0 +1,29 @@
+{
+	"addonId": "nvdaMacroManager",
+	"displayName": "NVDA Macro Manager",
+	"URL": "https://github.com/m-enes-senovali/nvdaMacroManager/releases/download/v1.2.3/nvdaMacroManager-1.2.3.nvda-addon",
+	"description": "A high-performance, OS-level macro recording, editing, and playback engine. Features include Stealth Mode recording, multi-event IDE, custom shortcuts, and dynamic speed multipliers.",
+	"sha256": "649a033ee7f3b98ceba2895a72cb78009614bf75e666bf98322d9668d9519db6",
+	"addonVersionName": "1.2.3",
+	"addonVersionNumber": {
+		"major": 1,
+		"minor": 2,
+		"patch": 3
+	},
+	"minNVDAVersion": {
+		"major": 2023,
+		"minor": 1,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2026,
+		"minor": 1,
+		"patch": 0
+	},
+	"channel": "stable",
+	"publisher": "Muhammet Enes Şenovalı",
+	"sourceURL": "https://github.com/m-enes-senovali/nvdaMacroManager",
+	"license": "GPL v2",
+	"homepage": "https://github.com/m-enes-senovali/nvdaMacroManager",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+}


### PR DESCRIPTION
## Add-on Update: NVDA Macro Manager v1.2.3

### Changes in this version:
- Added **Clipboard Sharing** feature to copy/import macros as Base64/Zlib text
- Fixed a critical bug where modifier keys (like Ctrl) could get stuck after macro playback
- Migrated to the official NVDA AddonTemplate structure
- Fixed translation file syntax errors in DE and ES locales
- Code style improvements for pre-commit compliance

### Add-on Details:
- **Add-on ID:** nvdaMacroManager
- **Version:** 1.2.3
- **Min NVDA Version:** 2023.1.0
- **Last Tested:** 2026.1.0
- **Channel:** stable
- **License:** GPL v2
- **SHA256:** `649a033ee7f3b98ceba2895a72cb78009614bf75e666bf98322d9668d9519db6`

### Download URL:
https://github.com/m-enes-senovali/nvdaMacroManager/releases/download/v1.2.3/nvdaMacroManager-1.2.3.nvda-addon