### PR TITLE
Update submitter docs

### DIFF
--- a/.github/workflows/checkFilesChanged.js
+++ b/.github/workflows/checkFilesChanged.js
@@ -11,7 +11,7 @@ function getAddonFileName(changedFiles) {
 				throw "Multiple add-on files updated."
 			}
 			if (fileData.status != "added") {
-				errMsg = "This is a resubmission of a previously submitted add-on version. This add-on version is already available in the Add-on Store. Please submit a new add-on version instead of modifying an existing one."
+				errMsg = "This add-on is already present in the Add-on Store with the same version number.\nPlease submit your add-on with a new version number instead of trying to modify an existing one."
 				// Ensure an error message is passed on to the user when this happens.
 				fs.writeFileSync("./validationErrors.md", errMsg)
 				throw errMsg

--- a/docs/design/jsonMetadata.md
+++ b/docs/design/jsonMetadata.md
@@ -1,18 +1,21 @@
-## JSON Metadata Schema details
+# JSON Metadata Schema details
+
 Each submission to the addon-datastore is structured as a JSON file, containing all the metadata needed for the NVDA Add-on Store.
 
-For a full description of the schema see the
-[_validate/addonVersion_schema.json file](https://github.com/nvaccess/addon-datastore-validation/blob/main/_validate/addonVersion_schema.json).
+For a full description of the schema refer to [`addonVersion_schema.json`](../../validation/_validate/addonVersion_schema.json).
 It includes an example of the file contents.
 
-### addonId
+## addonId
+
 The ID for the addon.
 This should match the name field in the addon manifest and the folder name for the submission.
 The suggested convention is a camelCaseName.
+It should only contain letters, numbers, hyphens, and underscores.
 
 Example: `easyAddonTech`
 
-### channel
+## channel
+
 Should be `"stable", "beta" or "dev"`.
 
 **Stable:** Suggested for add-on versions which are stable, and have been tested with a stable version of NVDA.
@@ -23,17 +26,15 @@ Suggested for testing with stable, beta or rc NVDA releases.
 **Dev**: This channel is suggested to be used with any preview or pre-release version of NVDA.
 This is useful for testing compatibility breaking changes in an API breaking release cycle, and unreleased additions to the NVDA API.
 
-### addonVersionNumber
+## addonVersionNumber
+
 The version of the add-on, as a major-minor-patch dictionary.
-Add-on versions are expected to be unique for the addonId,
-meaning that a beta, stable and dev add-on version cannot share a version number.
+Add-on versions are expected to be unique for the addonId, meaning that a beta, stable and dev add-on version cannot share a version number.
 This is so there can be a unique ordering of newest to oldest.
 Add-on versions should be released in order, newer versions will encourage an update.
 Users may be able to upgrade across channels in future.
 
-The suggested convention is to increment the patch version number for dev versions,
-increment the minor version number for beta versions,
-and increment the major version number for stable versions.
+The suggested convention is to increment the patch version number for dev versions, increment the minor version number for beta versions, and increment the major version number for stable versions.
 
 Example:
 ```json
@@ -44,36 +45,42 @@ Example:
 }
 ```
 
-### addonVersionName
+## addonVersionName
+
 The addon version being released.
 Should be in the form "`<major>.<minor>.<patch>`" or "`<major>.<minor>`".
 Must match the version in the addon manifest.
 
 Examples: `21.6.0`, `21.6`, `21.06`.
 
-### displayName
+## displayName
+
 The name that will be displayed in English for the addon.
 Must match the summary in the addon manifest.
 
 Example: `"Easy Addon"`
 
-### publisher
+## publisher
+
 The name of the individual, group, or company responsible for the addon.
 
 Example: `"NV Access"`
 
-### description
+## description
+
 The English description of the addon that will be displayed for the addon.
 
 Example: `"Makes doing XYZ easier"`
 
-### homepage
+## homepage
+
 If the addon has a homepage where users can get more information about the addon, you can specify it here.
 Must match the url in the addon manifest, which is optional.
 
 Example: `"https://github.com/nvaccess/addon-datastore"`
 
-### minNVDAVersion
+## minNVDAVersion
+
 The add-on will not work with versions of NVDA prior to this version.
 Must be a valid NVDA API version.
 Must match the minimumNVDAVersion in the addon manifest.
@@ -88,7 +95,8 @@ Example:
 }
 ```
 
-### lastTestedVersion
+## lastTestedVersion
+
 The add-on has been tested up to and including this version of NVDA.
 Must be a valid NVDA API version.
 Must match the lastTestedNVDAVersion in the addon manifest.
@@ -103,14 +111,16 @@ Example:
 }
 ```
 
-### URL
+## URL
+
 To allow directly downloading the *.nvda-addon file.
 The URL should remain valid indefinitely.
 GitHub release URLs are recommended.
 
 Example: `"https://github.com/nvaccess/addon-datastore/releases/download/v0.1.0/myAddon.nvda-addon"`
 
-### sha256
+## sha256
+
 The SHA256 checksum for the *.nvda-addon file.
 To calculate a SHA256 sum on Windows, run the following from command prompt:
 
@@ -120,35 +130,40 @@ certutil -hashfile <pathToAddonFile.nvda-addon> SHA256
 
 Example: `"69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82"`
 
-### sourceURL
+## sourceURL
+
 Allows reviewers to inspect the source code for common issues.
 
 Example: `"https://github.com/nvaccess/addon-datastore/"`
 
-### license
+## license
+
 The short name of the license
 
 Example: `"GPL v2"`
 
-### licenseURL
+## licenseURL
+
 Optional.
 A URL to the full license for the addon.
 
 Example: `"https://github.com/nvaccess/addon-datastore/license.MD"`
 
-### reviewUrl
+## reviewUrl
+
 Optional.
 A URL to the discussion comment to review the add-on version.
 
 Example: `"https://github.com/nvaccess/addon-datastore/discussions/1942#discussioncomment-7453248"`
 
-### submissionTime
+## submissionTime
+
 Optional.
 Timestamp of the add-on submission in milliseconds.
 
 Example: `1726667579000`
 
-### Changelog
+## Changelog
 
 Optional.
 

--- a/docs/submitters/submissionGuide.md
+++ b/docs/submitters/submissionGuide.md
@@ -5,42 +5,66 @@ Submitted add-ons should comply with the [NVDA code of conduct](https://github.c
 ## Background
 
 Submitting an add-on version is done via a [GitHub issue form](https://github.com/nvaccess/addon-datastore/issues/new?template=registerAddon.yml).
-A JSON metadata file is generated from the issue form and the add-on's manifest.
-A detailed description of the JSON schema can be found in [jsonMetadata.md](./jsonMetadata.md).
-When the issue form is submitted, the JSON file is generated and submitted as a pull request to the repository.
-VirusTotal is used to scan the submitted add-on for malicious content.
-NV Access will determine whether or not the detection should prevent the add-on from being accepted.
-
-Automated validation checks are run against the pull request.
-If there are validation errors, they will be commented on the pull request.
-Otherwise, the pull request will be merged, the issue will be closed and the add-on will become available in the Add-on Store.
-
-## Approval process
 
 Publishers must be approved to submit add-ons, on a per add-on basis.
 If you do not maintain the submitted add-on's repository, it is expected that you have authorisation to publish the add-on from the authors.
 It may take up to 2 weeks for approval for new add-ons.
+Once you have been approved to submit an add-on, future updates for the add-on should not require approval.
+
+VirusTotal is used to scan the submitted add-on for malicious content.
+If malicious content is detected, the add-on will be left pending until it can be reviewed.
+NV Access will determine whether or not the detection should prevent the add-on from being accepted.
+
+Automated validation checks are run against the pull request.
+If there are validation errors, they will be commented on the pull request.
+Otherwise, the add-on will become available in the Add-on Store.
 
 ## Steps to submit an add-on
 
 1. Open the ["Add-on registration" issue form](https://github.com/nvaccess/addon-datastore/issues/new?template=registerAddon.yml).
 1. Fill out and submit the issue form.
 This will create an issue with a summary of your submission, and generate a pull request to submit your add-on to the store.
-1. If this is your first submission of this add-on, [manual approval](#approval-process) will be required to be added to the approved submitters list for the add-on.
+1. If this is your first submission of this add-on, manual approval will be required to be added to the approved submitters list for the add-on.
 You do not need to do anything if you are the maintainer of the add-on you submitted.
 Please wait for an NV Access staff member to review the submission, it may take up to 2 weeks.
 1. Automated checks are ran on the pull request to validate the submission.
-Refer to [addon-datastore-validation](https://github.com/nvaccess/addon-datastore-validation) for more information on automated checks.
+Refer to [the validation section](#validation) for more information on automated checks.
 1. If the checks fail, a comment should be added to the issue outlining the failure.
 To address the issues, resubmit the issue form.
 You may need to also update your add-on manifest.
-Descriptions for the fields of the JSON schema can be found in [jsonMetadata.md](./jsonMetadata.md).
+Descriptions for the fields of the JSON schema can be found in [jsonMetadata.md](../design/jsonMetadata.md).
 1. The checks may fail due to code being flagged as malicious.
 Please review the flagged content and consider fixing them or commenting why they are a false positive.
 An NV Access staff will review the submission and consider accepting if they believe it is a false positive.
 This may take up to 2 weeks.
 1. If the checks pass, the pull request should be merged automatically.
-The add-on should soon become available in the store.
+The add-on should soon become available in the Add-on Store.
+
+## Validation
+
+The add-on manifest and the submitted information in the issue form must follow certain validation requirements.
+
+### Issue form validation
+
+* All URLs must start with `https://`.
+* Download URL is valid:
+  * Must start with `https://` and end with `.nvda-addon`.
+  * The URL is a direct download link that successfully downloads the `*.nvda-addon` file.
+* If the add-on manifest field `lastTestedNVDAVersion` refers to a release currently in beta or alpha, the channel must be set to `beta` or `dev`.
+NVDA API versions are listed in [`nvdaAPIVersions.json`](../../transform/nvdaAPIVersions.json).
+Those listed as `"experimental": true` mean that add-on API is not finalised for that release yet.
+An add-on referring or relying on that API version must be marked as `beta` or `dev`.
+
+### Add-on manifest validation
+
+* The manifest exists in the downloaded `*.nvda-addon` file and can be loaded by the `AddonManifest` class.
+* The `name` field:
+  * must be unique, other [add-ons already listed](../../addons) must not have a similar name.
+  * must consist of only letters, numbers, underscores and hyphens.
+* The `version` field must be of the form `major.minor` or `major.minor.patch`.
+* The `lastTestedNVDAVersion` and `minimumNVDAVersion` fields are valid NVDA API versions.
+These are listed in [`nvdaAPIVersions.json`](../../transform/nvdaAPIVersions.json).
+* All URLs must start with `https://`.
 
 ## Registering an add-on in the translation system
 

--- a/docs/submitters/submissionGuide.md
+++ b/docs/submitters/submissionGuide.md
@@ -27,7 +27,7 @@ This will create an issue with a summary of your submission, and generate a pull
 1. If this is your first submission of this add-on, manual approval will be required to be added to the approved submitters list for the add-on.
 You do not need to do anything if you are the maintainer of the add-on you submitted.
 Please wait for an NV Access staff member to review the submission, it may take up to 2 weeks.
-1. Automated checks are ran on the pull request to validate the submission.
+1. Automated checks are run on the pull request to validate the submission.
 Refer to [the validation section](#validation) for more information on automated checks.
 1. If the checks fail, a comment should be added to the issue outlining the failure.
 To address the issues, resubmit the issue form.


### PR DESCRIPTION
Part of #8464 

Updates submitter documentation, particularly:

* respond to phrasing issues for version conflicts from [this discussion](https://nvda-addons.groups.io/g/nvda-addons/topic/problem_updating_my_add_ons/120010179)
* improve formatting for json metadata doc
* move JSON metadata doc, it's TMI for submitters, it's more of a design spec
* add a simpler summary of validation requirements submitters must follow