### PR TITLE
fix up duplicates when approving an add-on for the first time multiple times

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -424,7 +424,12 @@ jobs:
       if: ${{ needs.requireSubmitterManualApproval.result == 'success' }}
       run: |
         jqCode="
-        .[\"${{ inputs.issueAuthorId }}\"].addons += [\"${{ needs.getAddonId.outputs.addonId }}\"]
+        .[\"${{ inputs.issueAuthorId }}\"].addons |= (
+          (. // []) |
+          if index(\"${{ needs.getAddonId.outputs.addonId }}\") then .
+          else . + [\"${{ needs.getAddonId.outputs.addonId }}\"]
+          end
+        )
         | .[\"${{ inputs.issueAuthorId }}\"].githubName = \"${{ inputs.issueAuthorName }}\"
         "
 

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -442,8 +442,12 @@ jobs:
       if: ${{ needs.requireSubmitterManualApproval.result == 'success' }}
       run: |
         git add submitters.json
-        git commit -m "Add ${{ inputs.issueAuthorName }} as an approved submitter for ${{ needs.getAddonId.outputs.addonId }}"
-        git push --set-upstream origin ${{ env.branchName }}
+        if git diff --staged --quiet; then
+          echo "No changes to submitters.json; skipping commit and push."
+        else
+          git commit -m "Add ${{ inputs.issueAuthorName }} as an approved submitter for ${{ needs.getAddonId.outputs.addonId }}"
+          git push --set-upstream origin ${{ env.branchName }}
+        fi
     - name: Check if discussion for this add-on exists
       id: checkDiscussion
       run: |

--- a/submitters.json
+++ b/submitters.json
@@ -25,8 +25,6 @@
 			"goldwave",
 			"evtTracker",
 			"zoomEnhancements",
-			"zoomEnhancements",
-			"brailleEssentials",
 			"brailleEssentials"
 		]
 	},
@@ -785,7 +783,6 @@
 			"AbsoluteWindows",
 			"AbsoluteTranslate",
 			"Listen",
-			"StateBeforeLabel",
 			"StateBeforeLabel"
 		],
 		"githubName": "chaichaimee"
@@ -839,7 +836,6 @@
 	"74401447": {
 		"addons": [
 			"pleasant_progress_bar",
-			"Am I In Frame",
 			"content_priority_reading"
 		],
 		"githubName": "c469591"
@@ -865,7 +861,6 @@
 	},
 	"111385085": {
 		"addons": [
-			"Bíblia Acessível",
 			"biblia-acessivel",
 			"blindGame"
 		],
@@ -964,8 +959,7 @@
 	"252786167": {
 		"addons": [
 			"simpleMediaPlayer",
-			"tussimulatoru",
-			"indirme bildiricisi"
+			"tussimulatoru"
 		],
 		"githubName": "firatatass"
 	},
@@ -1002,7 +996,6 @@
 	},
 	"246862942": {
 		"addons": [
-			"browser history remover",
 			"browserHistoryRemover"
 		],
 		"githubName": "blindtechvisionary"
@@ -1024,7 +1017,6 @@
 			"GBReader",
 			"lineDesktop",
 			"telegramDesktop",
-			"screenCurtainPassword",
 			"screenCurtainPassword"
 		],
 		"githubName": "keyang556"


### PR DESCRIPTION
Fixes #9962 

Only append the add-on ID if it isn't already in submitters.json

Also removes bad/duplicated add-on IDs from submitters.json

Tested the jq code locally

```sh
jqCode=".[\"authorId\"].addons |= (
  (. // []) |
  if index(\"addonId\") then .
  else . + [\"addonId\"]
  end
)
| .[\"authorId\"].githubName = \"authorName\"
"
jq -e --tab "$jqCode" test.json > test.2.json
```