### PR TITLE
Add Global Sonic Pitch 0.4.17

### DIFF
--- a/addons/globalSonicPitch/0.4.16.json
+++ b/addons/globalSonicPitch/0.4.16.json
@@ -1,0 +1,31 @@
+{
+	"addonId": "globalSonicPitch",
+	"addonVersionNumber": {
+		"major": 0,
+		"minor": 4,
+		"patch": 16
+	},
+	"addonVersionName": "0.4.16",
+	"displayName": "Global Sonic Pitch",
+	"publisher": "Kazek, DJ Graco",
+	"description": "Adds optional global Sonic pitch processing for NVDA speech audio.",
+	"homepage": "https://github.com/kazek5p-git/sonicpitch",
+	"minNVDAVersion": {
+		"major": 2025,
+		"minor": 1,
+		"patch": 0
+	},
+	"lastTestedVersion": {
+		"major": 2026,
+		"minor": 1,
+		"patch": 1
+	},
+	"channel": "stable",
+	"URL": "https://github.com/kazek5p-git/sonicpitch/releases/download/v0.4.16/globalSonicPitch-0.4.16.nvda-addon",
+	"sha256": "F122263679E96FA9F71FE85D0807614394EC903D14F2A3CDED2F275111008EA4",
+	"sourceURL": "https://github.com/kazek5p-git/sonicpitch",
+	"license": "GPL v2",
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html",
+	"submissionTime": 1783898106237,
+	"translations": []
+}


### PR DESCRIPTION
Adds Global Sonic Pitch 0.4.17 to the NVDA Add-on Store metadata.

Release: https://github.com/kazek5p-git/sonicpitch/releases/tag/v0.4.17
Download: https://github.com/kazek5p-git/sonicpitch/releases/download/v0.4.17/globalSonicPitch-0.4.17.nvda-addon
Source: https://github.com/kazek5p-git/sonicpitch
Publisher: Kazimierz Parzych, DJ Graco
Channel: stable
SHA256: DEDB792CED78157D6D3D38453CD7DC40FE88085724F2D51A2DB457DBA624876F

Local validation run:
python -m _validate.validate ..\addons\globalSonicPitch\0.4.17.json ..\transform\nvdaAPIVersions.json --output ..\validationErrors.md

Result: No validation errors.

Note: I first tried the official issue form path via GitHub CLI, but external accounts cannot add the autoSubmissionFromIssue label required by the automation. This PR contains the same metadata for maintainer review.