### PR TITLE
Fix GraphQL errors when merging

### DIFF
--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -526,6 +526,7 @@ jobs:
         git config user.email "github-actions@github.com"
         git fetch origin master
         git merge origin/master --no-edit
+        # Mitigate intermittent GitHub GraphQL errors by allowing PR merge state to settle.
         sleep 5
         gh pr merge --admin --squash ${{ env.branchName }} -b '[Automated] Merged ${{ needs.getAddonId.outputs.addonFileName }} into master (PR #${{ needs.createPullRequest.outputs.pullRequestNumber }})'
     - name: Comment on issue confirming successful submission

--- a/.github/workflows/checkAndSubmitAddonMetadata.yml
+++ b/.github/workflows/checkAndSubmitAddonMetadata.yml
@@ -526,6 +526,7 @@ jobs:
         git config user.email "github-actions@github.com"
         git fetch origin master
         git merge origin/master --no-edit
+        sleep 5
         gh pr merge --admin --squash ${{ env.branchName }} -b '[Automated] Merged ${{ needs.getAddonId.outputs.addonFileName }} into master (PR #${{ needs.createPullRequest.outputs.pullRequestNumber }})'
     - name: Comment on issue confirming successful submission
       env:


### PR DESCRIPTION
# Related issue

Fixes #10139 

### Summary of the issue
Sometimes, when trying to merge a Branch created from an add-on submission, a GraphQL is produced, and the Branch cannot be automatically merged.
### Development approach
Wait 5 seconds before merging (`sleep 5` in the corresponding workflow).
# Testing performed
https://github.com/nvdaes/addon-datastore/pull/1485



