### PR TITLE
Add link to the submitters guide to improve validation errors message

### DIFF
--- a/validation/_validate/createJson.py
+++ b/validation/_validate/createJson.py
@@ -113,7 +113,7 @@ def createDataclassMatchingJsonSchema(
 	try:
 		addonVersionNumber = MajorMinorPatch.getFromStr(cast(str, manifest["version"]))
 	except ValueError as e:
-		raise ValueError(f"Manifest value for 'version' is invalid {manifest['version']}") from e
+		raise ValueError(f"Manifest value for 'version' is invalid {manifest['version']}. Format must be major.minor or major.minor.patch") from e
 
 	for key in ("name", "summary", "description", "minimumNVDAVersion", "lastTestedNVDAVersion", "version"):
 		if key not in manifest:

--- a/validation/_validate/createJson.py
+++ b/validation/_validate/createJson.py
@@ -114,7 +114,7 @@ def createDataclassMatchingJsonSchema(
 		addonVersionNumber = MajorMinorPatch.getFromStr(cast(str, manifest["version"]))
 	except ValueError as e:
 		raise ValueError(
-			f"Manifest value for 'version' is invalid {manifest['version']}. Format must be major.minor or major.minor.patch"
+			f"Manifest value for 'version' is invalid {manifest['version']}. Format must be major.minor or major.minor.patch",
 		) from e
 
 	for key in ("name", "summary", "description", "minimumNVDAVersion", "lastTestedNVDAVersion", "version"):

--- a/validation/_validate/createJson.py
+++ b/validation/_validate/createJson.py
@@ -113,7 +113,9 @@ def createDataclassMatchingJsonSchema(
 	try:
 		addonVersionNumber = MajorMinorPatch.getFromStr(cast(str, manifest["version"]))
 	except ValueError as e:
-		raise ValueError(f"Manifest value for 'version' is invalid {manifest['version']}. Format must be major.minor or major.minor.patch") from e
+		raise ValueError(
+			f"Manifest value for 'version' is invalid {manifest['version']}. Format must be major.minor or major.minor.patch"
+		) from e
 
 	for key in ("name", "summary", "description", "minimumNVDAVersion", "lastTestedNVDAVersion", "version"):
 		if key not in manifest:

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -407,7 +407,7 @@ def outputErrors(errors: list[str], errorFilePath: str | None = None):
 				errorFile.write(
 					"This add-on submission has validation errors. "
 					"Please submit a new version with the errors fixed. "
-					"To get help fixing the errors, read the Add-on Manifest Validation section of the [Submission Guide](https://github.com/nvaccess/addon-datastore/blob/master/docs/submitters/submissionGuide.md#add-on-manifest-validation). "
+					"To get help fixing the errors, read the Add-on Manifest Validation section of the [Submission Guide](https://github.com/nvaccess/addon-datastore/blob/master/docs/submitters/submissionGuide.md#add-on-manifest-validation).\n"
 					"Errors:\n- " + "\n- ".join(errors) + "\n\n",
 				)
 

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -407,7 +407,7 @@ def outputErrors(errors: list[str], errorFilePath: str | None = None):
 				errorFile.write(
 					"This add-on submission has validation errors. "
 					"Please submit a new version with the errors fixed. "
-					"To get help fixing the errors, read the Add-on Manifest Validation section of the [Submission Guide](https://github.com/nvaccess/addon-datastore/blob/master/docs/submitters/submissionGuide.md#add-on-manifest-validation) "
+					"To get help fixing the errors, read the Add-on Manifest Validation section of the [Submission Guide](https://github.com/nvaccess/addon-datastore/blob/master/docs/submitters/submissionGuide.md#add-on-manifest-validation). "
 					"Errors:\n- " + "\n- ".join(errors) + "\n\n",
 				)
 

--- a/validation/_validate/validate.py
+++ b/validation/_validate/validate.py
@@ -407,6 +407,7 @@ def outputErrors(errors: list[str], errorFilePath: str | None = None):
 				errorFile.write(
 					"This add-on submission has validation errors. "
 					"Please submit a new version with the errors fixed. "
+					"To get help fixing the errors, read the Add-on Manifest Validation section of the [Submission Guide](https://github.com/nvaccess/addon-datastore/blob/master/docs/submitters/submissionGuide.md#add-on-manifest-validation) "
 					"Errors:\n- " + "\n- ".join(errors) + "\n\n",
 				)
 


### PR DESCRIPTION
### Issue number
Fixes #10706 

### Summary of the issue

Sometimes, may be difficult to know how to fix errors when the validation of an add-on shows errors.

### Approach

Added a link to the Add-on Manifest Validation section of the Submission Guide.
