### PR TITLE
Add eyewazUrdu 1.0.0

### DIFF
--- a/addons/eyewazUrdu/1.0.0.json
+++ b/addons/eyewazUrdu/1.0.0.json
@@ -1,0 +1,29 @@
+{
+    "addonId": "eyewazUrdu",
+    "displayName": "EYEWAZ Urdu Voice",
+    "URL": "https://github.com/yas1i/eyewaz-backend/releases/download/v1.0.0/EyewazUrdu-1.0.0.nvda-addon",
+    "description": "Natural, fully offline Urdu text to speech for the NVDA screen reader. Powered by EYEWAZ and trained on real WAJD AI voices, so NVDA reads Urdu in a clear human voice with no internet and no per character cost. Choose a female or male voice in NVDA, Speech settings.",
+    "sha256": "eafeb9659d07496a4408588224242838ca047cc4229f2dcc9c3f2bad3ed3b7ce",
+    "homepage": "https://www.eyewaz.com",
+    "addonVersionName": "1.0.0",
+    "addonVersionNumber": {
+        "major": 1,
+        "minor": 0,
+        "patch": 0
+    },
+    "minNVDAVersion": {
+        "major": 2021,
+        "minor": 1,
+        "patch": 0
+    },
+    "lastTestedVersion": {
+        "major": 2026,
+        "minor": 1,
+        "patch": 0
+    },
+    "channel": "stable",
+    "publisher": "WAJD AI",
+    "sourceURL": "https://github.com/yas1i/eyewaz-backend",
+    "license": "GPL v2",
+    "licenseURL": "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
+}


### PR DESCRIPTION
Adds EYEWAZ Urdu Voice 1.0.0, a new speech synthesizer add-on.

Natural, fully offline Urdu text to speech for NVDA, with a female and a male voice trained on recorded human voices. Runs entirely on the user's machine (bundled Piper runtime), so no internet is needed and nothing the user reads leaves the computer. Includes word tracking for caret following.

I am the add-on author and maintainer. Source: https://github.com/yas1i/eyewaz-backend (nvda-addon folder). Licence: GPL v2. Tested on NVDA 2026.1.1 on Windows 11.